### PR TITLE
Add support for 'has-resource' syntax

### DIFF
--- a/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
+++ b/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
@@ -37,6 +37,7 @@ property       : edge
                | propRhs
                | propHasFlag
                | propHasPred
+               | propResource
                | propRel
                | isAbstract
                | propDatatype
@@ -44,7 +45,17 @@ property       : edge
 
 insertPatterns : insertPattern (';' insertPattern)* ';'? ;
 insertPattern  : variable? insert (','? insert)* ;
-insert         : edge | propId | propVal | propLhs | propRhs | insertRel | propHas | isAbstract | propDatatype;
+insert         : edge
+               | propId
+               | propVal
+               | propLhs
+               | propRhs
+               | insertRel
+               | propHas
+               | propResource
+               | isAbstract
+               | propDatatype
+               ;
 
 deletePatterns : deletePattern (';' deletePattern)* ';'? ;
 deletePattern  : VARIABLE (delete ','?)* delete? ;
@@ -62,6 +73,8 @@ propRhs        : 'rhs' '{' query '}' ;
 propHasFlag    : 'has' id ;
 propHas        : 'has' id value ;
 propHasPred    : 'has' id predicate ;
+
+propResource   : 'has-resource' id ;
 
 propDatatype   : 'datatype' DATATYPE ;
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/Var.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/Var.java
@@ -138,6 +138,12 @@ public interface Var extends Pattern {
     Var hasScope(Var type);
 
     /**
+     * @param type a resource type that this type variable can be related to
+     * @return this
+     */
+    Var hasResource(String type);
+
+    /**
      * the variable must be a relation with the given roleplayer
      *
      * @param roleplayer a variable representing a roleplayer
@@ -280,6 +286,11 @@ public interface Var extends Pattern {
          * @return all scopes this relation has
          */
         Set<Var.Admin> getScopes();
+
+        /**
+         * @return all resource types that this type's instances can have
+         */
+        Set<Var.Admin> getHasResourceTypes();
 
         /**
          * @return the datatype of this resource type, if one is set

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/GraqlType.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/GraqlType.java
@@ -4,24 +4,30 @@ package io.mindmaps.graql.internal;
  * Some constant types that Graql needs to know about.
  * This is currently only the has-resource relationship, which is not automatically added to the ontology
  */
-public class GraqlType {
-
-    private GraqlType() {
-
-    }
+public enum GraqlType {
 
     /**
      * The id of the generic has-resource relationship, used for attaching resources to instances with the 'has' syntax
      */
-    public static final String HAS_RESOURCE = "has-resource";
+    HAS_RESOURCE("has-%s"),
 
     /**
      * The id of a role in has-resource, played by the owner of the resource
      */
-    public static final String HAS_RESOURCE_TARGET = "has-resource-target";
+    HAS_RESOURCE_OWNER("has-%s-owner"),
 
     /**
      * The id of a role in has-resource, played by the resource
      */
-    public static final String HAS_RESOURCE_VALUE = "has-resource-value";
+    HAS_RESOURCE_VALUE("has-%s-value");
+
+    private final String name;
+
+    private GraqlType(String name) {
+        this.name = name;
+    }
+
+    public String getId(String resourceTypeId) {
+        return String.format(name, resourceTypeId);
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
@@ -216,6 +216,12 @@ public class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
+    public Object visitPropResource(GraqlParser.PropResourceContext ctx) {
+        patterns.peek().hasResource(visitId(ctx.id()));
+        return null;
+    }
+
+    @Override
     public Void visitIsAbstract(GraqlParser.IsAbstractContext ctx) {
         patterns.peek().isAbstract();
         return null;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
@@ -43,6 +43,7 @@ public class VarImpl implements Var.Admin {
     private final Set<Var.Admin> hasRole = new HashSet<>();
     private final Set<Var.Admin> playsRole = new HashSet<>();
     private final Set<Var.Admin> hasScope = new HashSet<>();
+    private final Set<Var.Admin> hasResourceTypes = new HashSet<>();
 
     private final Map<Var.Admin, Set<ValuePredicate.Admin>> resources = new HashMap<>();
 
@@ -185,6 +186,12 @@ public class VarImpl implements Var.Admin {
     }
 
     @Override
+    public Var hasResource(String type) {
+        hasResourceTypes.add(QueryBuilder.id(type).admin());
+        return this;
+    }
+
+    @Override
     public Var rel(Var roleplayer) {
         castings.add(new Casting(roleplayer.admin()));
         return this;
@@ -284,6 +291,11 @@ public class VarImpl implements Var.Admin {
     @Override
     public Set<Var.Admin> getScopes() {
         return hasScope;
+    }
+
+    @Override
+    public Set<Var.Admin> getHasResourceTypes() {
+        return hasResourceTypes;
     }
 
     @Override
@@ -395,6 +407,7 @@ public class VarImpl implements Var.Admin {
             var.getHasRoles().forEach(newVars::add);
             var.getPlaysRoles().forEach(newVars::add);
             var.getScopes().forEach(newVars::add);
+            var.getHasResourceTypes().forEach(newVars::add);
             var.getResourcePredicates().keySet().forEach(newVars::add);
 
             var.getCastings().forEach(casting -> {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/validation/ErrorMessage.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/validation/ErrorMessage.java
@@ -35,10 +35,7 @@ public enum ErrorMessage {
     INSERT_MULTIPLE_VALUES("a concept cannot have multiple values %s and '%s'"),
     INSERT_ISA_AND_AKO("cannot insert %s with an isa and an ako"),
     INSERT_NO_DATATYPE("resource type %s must have a datatype defined"),
-    INSERT_NO_RESOURCE_RELATION(
-            "adding a resource with 'has' requires a 'has-resource' relation type " +
-            "with roles 'has-resource-target' and 'has-resource-value'"
-    ),
+    INSERT_NO_RESOURCE_RELATION("type %s cannot have resource type %s"),
     INSERT_METATYPE("%s cannot be a subtype of meta-type %s"),
     INSERT_RECURSIVE("%s should not refer to itself"),
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryTest.java
@@ -259,7 +259,7 @@ public class MatchQueryTest {
     @Test
     public void testTypeAsVariable() {
         MatchQuery query = qb.match(id("genre").playsRole(var("x")));
-        QueryUtil.assertResultsMatch(query, "x", null, "genre-of-production", "has-resource-target");
+        QueryUtil.assertResultsMatch(query, "x", null, "genre-of-production");
     }
 
     @Test

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
@@ -132,7 +132,7 @@ public class QueryErrorTest {
 
     @Test
     public void testExceptionWhenNoHasResourceRelation() {
-        // Create a fresh graph, with no has-resource relationship
+        // Create a fresh graph, with no has-resource between person and name
         MindmapsTransaction empty = MindmapsTestGraphFactory.newEmptyGraph().newTransaction();
 
         QueryBuilder emptyQb = QueryBuilder.build(empty);
@@ -143,9 +143,8 @@ public class QueryErrorTest {
 
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(
-                containsString("has-resource"),
-                containsString("has-resource-target"),
-                containsString("has-resource-value")
+                containsString("person"),
+                containsString("name")
         ));
         emptyQb.insert(var().isa("person").has("name", "Bob")).execute();
     }

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/examples/ExamplesTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/examples/ExamplesTest.java
@@ -74,14 +74,10 @@ public class ExamplesTest {
         );
 
         load(
-                "insert has-resource isa relation-type;",
-                "insert has-resource-target isa role-type;",
-                "insert has-resource-value isa role-type;",
-                "insert has-resource has-role has-resource-target;",
-                "insert has-resource has-role has-resource-value;",
-                "insert person plays-role has-resource-target;",
-                "insert title isa resource-type, datatype string, plays-role has-resource-value;",
-                "insert epithet isa resource-type, datatype string, plays-role has-resource-value;"
+                "insert title isa resource-type, datatype string",
+                "insert epithet isa resource-type, datatype string",
+                "insert person has-resource title",
+                "insert person has-resource epithet"
         );
 
         load(


### PR DESCRIPTION
'has-resource' is used between a type and a resource type and will automatically create a relation type connecting the two.