### PR TITLE
Hal path master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,5 @@ db/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-# junk files #
-mindmaps-engine/transaction-manager.log
-
+# Log files #
+logs/

--- a/conf/mindmaps-engine-test.properties
+++ b/conf/mindmaps-engine-test.properties
@@ -18,14 +18,14 @@
 
 
 # Logging
-logging.file=./transaction-manager.log
+logging.file=../logs/transaction-manager.log
 logging.level.=INFO
 
 #Titan Config
-graphdatabase.config=../conf/mindmaps.properties
+graphdatabase.config=../conf/mindmaps-test.properties
 graphdatabase.batch-config=../conf/mindmaps-batch.properties
-graphdatabase.computer=../conf/mindmaps-analytics.properties
-graphdatabase.default-graph-name=mindmaps
+graphdatabase.computer=../conf/mindmaps-test.properties
+graphdatabase.default-graph-name=mindmapstest
 
 #Spark Config
 server.port=4567
@@ -35,14 +35,12 @@ server.host=localhost
 loader.repeat-commits=5
 
 #Blocking Loader Config
-blockingLoader.batch-size=60
-blockingLoader.num-threads=30
+blockingLoader.batch-size=1
+blockingLoader.num-threads=16
 
 #HAL Builder Config
 halBuilder.degree = 1
-halBuilder.resource-prefix=http://localhost:4567/concept/
 
-#Background tasks Config
 backgroundTasks.post-processing-delay=300000
 backgroundTasks.maintenance-iteration=1000000
 loader.threads=8

--- a/conf/mindmaps-engine-test.properties
+++ b/conf/mindmaps-engine-test.properties
@@ -30,6 +30,7 @@ graphdatabase.default-graph-name=mindmapstest
 #Spark Config
 server.port=4567
 server.host=localhost
+server.static-file-dir=../assets/
 
 #RESTLoader Config
 loader.repeat-commits=5

--- a/conf/mindmaps-engine.properties
+++ b/conf/mindmaps-engine.properties
@@ -18,31 +18,31 @@
 
 
 # Logging
-logging.file=./transaction-manager.log
+logging.file=../logs/transaction-manager.log
 logging.level.=INFO
 
 #Titan Config
-graphdatabase.config=../conf/mindmaps-test.properties
+graphdatabase.config=../conf/mindmaps.properties
 graphdatabase.batch-config=../conf/mindmaps-batch.properties
-graphdatabase.computer=../conf/mindmaps-test.properties
-graphdatabase.default-graph-name=mindmapstest
+graphdatabase.computer=../conf/mindmaps-analytics.properties
+graphdatabase.default-graph-name=mindmaps
 
 #Spark Config
 server.port=4567
 server.host=localhost
+server.static-file-dir=../assets/
 
 #RESTLoader Config
 loader.repeat-commits=5
 
 #Blocking Loader Config
-blockingLoader.batch-size=1
-blockingLoader.num-threads=16
+blockingLoader.batch-size=60
+blockingLoader.num-threads=30
 
 #HAL Builder Config
 halBuilder.degree = 1
-halBuilder.resource-prefix=http://localhost:4567/concept/
 
+#Background tasks Config
 backgroundTasks.post-processing-delay=300000
 backgroundTasks.maintenance-iteration=1000000
 loader.threads=8
-

--- a/mindmaps-base/src/main/java/io/mindmaps/constants/RESTUtil.java
+++ b/mindmaps-base/src/main/java/io/mindmaps/constants/RESTUtil.java
@@ -12,8 +12,8 @@ public class RESTUtil {
         public static final String MATCH_QUERY_URI = "/shell/match";
         public static final String HOME_URI = "/";
 
-        public static final String CONCEPT_BY_ID_URI = "/concept/:id" ;
-        public static final String CONCEPTS_BY_VALUE_URI = "/concepts";
+        public static final String CONCEPT_BY_ID_URI = "/graph/concept/" ;
+
         public static final String COMMIT_LOG_URI = "/commit_log";
 
         public static final String NEW_TRANSACTION_URI = "/transaction/new";

--- a/mindmaps-dist/src/bin/mindmaps.sh
+++ b/mindmaps-dist/src/bin/mindmaps.sh
@@ -91,7 +91,7 @@ start)
         # engine has not already started
         echo -n "Starting engine"
         SCRIPTPATH=`cd "$(dirname "$0")" && pwd -P`
-        java -cp "`dirname $path`/../lib/*" -Dmindmaps.dir=$SCRIPTPATH MindmapsEngineServer > /dev/null &
+        java -cp "`dirname $path`/../lib/*" -Dmindmaps.dir=$SCRIPTPATH io.mindmaps.MindmapsEngineServer > /dev/null &
         echo $!>$ENGINE_PS
         wait_for_engine
     fi

--- a/mindmaps-dist/src/bin/mindmaps.sh
+++ b/mindmaps-dist/src/bin/mindmaps.sh
@@ -90,7 +90,8 @@ start)
     else
         # engine has not already started
         echo -n "Starting engine"
-        java -cp "`dirname $path`/../lib/*" MindmapsEngineServer > /dev/null &
+        SCRIPTPATH=`cd "$(dirname "$0")" && pwd -P`
+        java -cp "`dirname $path`/../lib/*" -Dmindmaps.dir=$SCRIPTPATH MindmapsEngineServer > /dev/null &
         echo $!>$ENGINE_PS
         wait_for_engine
     fi
@@ -104,7 +105,7 @@ stop)
         rm $ENGINE_PS
     fi
 
-    echo "Stopping casasndra"
+    echo "Stopping cassandra"
     if [[ -e $CASSANDRA_PS ]]; then
         kill `cat $CASSANDRA_PS`
         rm $CASSANDRA_PS

--- a/mindmaps-dist/src/dist.xml
+++ b/mindmaps-dist/src/dist.xml
@@ -45,6 +45,17 @@
                 <include>**</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <outputDirectory>assets</outputDirectory>
+            <directory>${project.parent.basedir}/assets/</directory>
+            <includes>
+                <include>**</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>logs</outputDirectory>
+            <directory>${project.parent.basedir}/logs/</directory>
+        </fileSet>
     </fileSets>
 
     <dependencySets>

--- a/mindmaps-engine/pom.xml
+++ b/mindmaps-engine/pom.xml
@@ -51,11 +51,6 @@
             <version>${halbuilder-standard.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${rest-assured.version}</version>
@@ -69,26 +64,11 @@
         <dependency>
             <groupId>org.sharegov</groupId>
             <artifactId>mjson</artifactId>
-            <version>1.3</version>
+            <version>${mjson.version}</version>
         </dependency>
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                        </manifest>
-                        <manifestEntries>
-                            <Class-Path>../</Class-Path>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.raml.plugins</groupId>
                 <artifactId>jaxrs-raml-maven-plugin</artifactId>

--- a/mindmaps-engine/src/main/java/MindmapsEngineServer.java
+++ b/mindmaps-engine/src/main/java/MindmapsEngineServer.java
@@ -21,24 +21,25 @@ import ch.qos.logback.classic.Logger;
 import io.mindmaps.api.*;
 import io.mindmaps.util.ConfigProperties;
 
+import java.net.URISyntaxException;
+
 import static spark.Spark.port;
+import static spark.Spark.staticFileLocation;
+import static spark.Spark.staticFiles;
 
 public class MindmapsEngineServer {
 
     public static void main(String[] args) {
 
-
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
-
 
         ConfigProperties prop = ConfigProperties.getInstance();
 
         // Listening port
         port(prop.getPropertyAsInt(ConfigProperties.SERVER_PORT_NUMBER));
-
-        // --------------------------------- //
-
+        //TODO: ADD ABSOLUTE PATHHHHHHHH
+        staticFiles.externalLocation(prop.getProperty(ConfigProperties.STATIC_FILES_PATH));
 
         // ----- APIs --------- //
 

--- a/mindmaps-engine/src/main/java/io/mindmaps/MindmapsEngineServer.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/MindmapsEngineServer.java
@@ -1,4 +1,4 @@
-/*
+package io.mindmaps;/*
  * MindmapsDB - A Distributed Semantic Database
  * Copyright (C) 2016  Mindmaps Research Ltd
  *
@@ -38,8 +38,7 @@ public class MindmapsEngineServer {
 
         // Listening port
         port(prop.getPropertyAsInt(ConfigProperties.SERVER_PORT_NUMBER));
-        //TODO: ADD ABSOLUTE PATHHHHHHHH
-        staticFiles.externalLocation(prop.getProperty(ConfigProperties.STATIC_FILES_PATH));
+        staticFiles.externalLocation(ConfigProperties.getProjectPath()+prop.getProperty(ConfigProperties.STATIC_FILES_PATH));
 
         // ----- APIs --------- //
 

--- a/mindmaps-engine/src/main/java/io/mindmaps/api/GraphFactoryController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/api/GraphFactoryController.java
@@ -40,31 +40,33 @@ public class GraphFactoryController {
     private final Logger LOG = LoggerFactory.getLogger(GraphFactoryController.class);
 
     public GraphFactoryController() {
+        ConfigProperties prop = ConfigProperties.getInstance();
+
+
         get(RESTUtil.WebPath.GRAPH_FACTORY_URI, (req, res) -> {
             String graphConfig = req.queryParams(RESTUtil.Request.GRAPH_CONFIG_PARAM);
 
             try {
-                if(graphConfig == null) {
+                if (graphConfig == null) {
                     graphConfig = ConfigProperties.GRAPH_CONFIG_PROPERTY;
                 } else {
-                  switch (graphConfig){
-                      case RESTUtil.GraphConfig.DEFAULT:
-                          graphConfig = ConfigProperties.GRAPH_CONFIG_PROPERTY;
-                          break;
-                      case RESTUtil.GraphConfig.BATCH:
-                          graphConfig = ConfigProperties.GRAPH_BATCH_CONFIG_PROPERTY;
-                          break;
-                      case RESTUtil.GraphConfig.COMPUTER:
-                          graphConfig = ConfigProperties.GRAPH_COMPUTER_CONFIG_PROPERTY;
-                          break;
-                  }
+                    switch (graphConfig) {
+                        case RESTUtil.GraphConfig.DEFAULT:
+                            graphConfig = ConfigProperties.GRAPH_CONFIG_PROPERTY;
+                            break;
+                        case RESTUtil.GraphConfig.BATCH:
+                            graphConfig = ConfigProperties.GRAPH_BATCH_CONFIG_PROPERTY;
+                            break;
+                        case RESTUtil.GraphConfig.COMPUTER:
+                            graphConfig = ConfigProperties.GRAPH_COMPUTER_CONFIG_PROPERTY;
+                            break;
+                    }
                 }
-
-                return new String(Files.readAllBytes(Paths.get(ConfigProperties.getInstance().getProperty(graphConfig))));
+                return new String(Files.readAllBytes(Paths.get(ConfigProperties.getProjectPath() + prop.getProperty(graphConfig))));
             } catch (IOException e) {
-                LOG.error(ErrorMessage.NO_CONFIG_FILE.getMessage(ConfigProperties.getInstance().getProperty(graphConfig)));
+                LOG.error(ErrorMessage.NO_CONFIG_FILE.getMessage(ConfigProperties.getProjectPath() + prop.getProperty(graphConfig)));
                 res.status(500);
-                return ErrorMessage.NO_CONFIG_FILE.getMessage(ConfigProperties.getInstance().getProperty(graphConfig));
+                return ErrorMessage.NO_CONFIG_FILE.getMessage(ConfigProperties.getProjectPath() + prop.getProperty(graphConfig));
             }
         });
 

--- a/mindmaps-engine/src/main/java/io/mindmaps/api/ImportController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/api/ImportController.java
@@ -151,6 +151,7 @@ public class ImportController {
 
     private void consumeRelation(Var var) {
         boolean ready = false;
+
         if (var.admin().isRelation()) {
             ready = true;
             //If one of the role players is defined using a variable name and the variable name is not in our cache we cannot insert the relation.

--- a/mindmaps-engine/src/main/java/io/mindmaps/api/RemoteShellController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/api/RemoteShellController.java
@@ -65,7 +65,7 @@ public class RemoteShellController {
     @Path("/metaTypeInstances")
     @ApiOperation(
             value = "Produces a JSONObject containing meta-ontology types instances.",
-            notes = "The built JSONObject will contain instances of roles, entities, relations and resources.",
+            notes = "The built JSONObject will contain ontology nodes divided in roles, entities, relations and resources.",
             response = JSONObject.class)
     @ApiImplicitParams({
             @ApiImplicitParam(name = "graphName", value = "Name of graph tu use", dataType = "string", paramType = "query")

--- a/mindmaps-engine/src/main/java/io/mindmaps/api/TransactionController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/api/TransactionController.java
@@ -23,7 +23,6 @@ import io.mindmaps.loader.RESTLoader;
 import io.mindmaps.util.ConfigProperties;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import spark.Request;
 import spark.Response;
@@ -60,9 +59,7 @@ public class TransactionController {
     @ApiOperation(
             value = "Load a new transaction made of Graql insert queries into the graph.",
             notes = "The body of the request must only contain the insert Graql strings.")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "graphName", value = "Name of graph to use", dataType = "string", paramType = "query")
-    })
+    @ApiImplicitParam(name = "graphName", value = "Name of graph to use", dataType = "string", paramType = "query")
     private String newTransactionREST(Request req, Response res){
         String currentGraphName = req.queryParams(RESTUtil.Request.GRAPH_NAME_PARAM);
         if (currentGraphName == null) currentGraphName = defaultGraphName;
@@ -80,9 +77,7 @@ public class TransactionController {
     @Path("/status/:uuid")
     @ApiOperation(
             value = "Returns the status of the transaction associated to the given UUID.")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "uuid", value = "UUID of the transaction", required = true, dataType = "string", paramType = "path")
-    })
+    @ApiImplicitParam(name = "uuid", value = "UUID of the transaction", required = true, dataType = "string", paramType = "path")
     private String checkTransactionStatusREST(Request req, Response res){
         try {
             return loader.getStatus(UUID.fromString(req.params(RESTUtil.Request.UUID_PARAMETER)));

--- a/mindmaps-engine/src/main/java/io/mindmaps/api/VisualiserController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/api/VisualiserController.java
@@ -18,9 +18,9 @@
 
 package io.mindmaps.api;
 
+import io.mindmaps.MindmapsTransaction;
 import io.mindmaps.constants.ErrorMessage;
 import io.mindmaps.constants.RESTUtil;
-import io.mindmaps.MindmapsTransaction;
 import io.mindmaps.core.model.Concept;
 import io.mindmaps.factory.GraphFactory;
 import io.mindmaps.util.ConfigProperties;
@@ -38,24 +38,14 @@ public class VisualiserController {
 
         defaultGraphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
 
-        get(RESTUtil.WebPath.CONCEPTS_BY_VALUE_URI, this::getConceptsByValue);
+        get(RESTUtil.WebPath.CONCEPT_BY_ID_URI + RESTUtil.Request.ID_PARAMETER, this::getConceptById);
 
-        get(RESTUtil.WebPath.CONCEPT_BY_ID_URI, this::getConceptById);
-
-    }
-
-    private String getConceptsByValue(Request req, Response res) {
-
-        // TODO: Implement HAL builder for concepts retrieved by Value, this still does not work.
-
-        GraphFactory.getInstance().getGraph(defaultGraphName).getTransaction().getConceptsByValue(req.queryParams(RESTUtil.Request.VALUE_FIELD));
-        return req.queryParams(RESTUtil.Request.VALUE_FIELD);
     }
 
     private String getConceptById(Request req, Response res) {
 
         String graphNameParam = req.queryParams(RESTUtil.Request.GRAPH_NAME_PARAM);
-        String currentGraphName = (graphNameParam==null) ? defaultGraphName : graphNameParam;
+        String currentGraphName = (graphNameParam == null) ? defaultGraphName : graphNameParam;
 
         MindmapsTransaction transaction = GraphFactory.getInstance().getGraph(currentGraphName).getTransaction();
 

--- a/mindmaps-engine/src/main/java/io/mindmaps/util/ConfigProperties.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/util/ConfigProperties.java
@@ -18,12 +18,13 @@
 
 package io.mindmaps.util;
 
+import java.io.FileInputStream;
 import java.util.Properties;
 
 public class ConfigProperties {
 
-    public static final String CONFIG_FILE = "application.properties";
-    public static final String CONFIG_TEST_FILE = "application.properties";
+    public static final String CONFIG_FILE = "../conf/mindmaps-engine.properties";
+    public static final String TEST_CONFIG_FILE = "../conf/mindmaps-engine-test.properties";
 
     public static final String GRAPH_CONFIG_PROPERTY = "graphdatabase.config";
     public static final String GRAPH_BATCH_CONFIG_PROPERTY = "graphdatabase.batch-config";
@@ -38,35 +39,54 @@ public class ConfigProperties {
     public static final String SERVER_PORT_NUMBER = "server.port";
 
     public static final String HAL_DEGREE_PROPERTY = "halBuilder.degree";
-    public static final String HAL_RESOURCE_PREFIX = "halBuilder.resource-prefix";
 
     public static final String LOADER_REPEAT_COMMITS = "loader.repeat-commits";
 
     public static final String MAINTENANCE_ITERATION = "backgroundTasks.maintenance-iteration";
-    public static final String LOGGING_FILE_PATH= "logging.file";
+
+    public static final String LOGGING_FILE_PATH = "logging.file";
     public static final String DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
+    public static final String STATIC_FILES_PATH = "server.static-file-dir";
+
+    public static final String CURRENT_DIR_SYSTEM_PROPERTY = "mindmaps.dir";
+    public static final String CONFIG_FILE_SYSTEM_PROPERTY = "mindmaps.conf";
 
 
     private Properties prop;
     private static ConfigProperties instance = null;
 
-
-    public synchronized static ConfigProperties getInstance(){
-        if(instance==null) instance=new ConfigProperties();
+    public synchronized static ConfigProperties getInstance() {
+        if (instance == null) instance = new ConfigProperties();
         return instance;
     }
 
-    private ConfigProperties(){
+
+    public static String getProjectPath() {
+        return (System.getProperty(CURRENT_DIR_SYSTEM_PROPERTY) != null) ? System.getProperty(CURRENT_DIR_SYSTEM_PROPERTY) + "/" : System.getProperty("user.dir") + "/";
+    }
+
+    public String getConfigFilePath() {
+        return (System.getProperty(CONFIG_FILE_SYSTEM_PROPERTY) != null) ? System.getProperty(CONFIG_FILE_SYSTEM_PROPERTY) : ConfigProperties.CONFIG_FILE;
+    }
+
+    private ConfigProperties() {
         prop = new Properties();
         try {
-            prop.load(getClass().getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_FILE));
+            prop.load(new FileInputStream(getProjectPath() + getConfigFilePath()));
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public String getProperty(String property){
+    public Properties getProperties() {
+        return prop;
+    }
+
+    public String getProperty(String property) {
         return prop.getProperty(property);
     }
-    public int getPropertyAsInt(String property) {return Integer.parseInt(prop.getProperty(property));}
+
+    public int getPropertyAsInt(String property) {
+        return Integer.parseInt(prop.getProperty(property));
+    }
 }

--- a/mindmaps-engine/src/test/java/io/mindmaps/api/CommitLogControllerTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/api/CommitLogControllerTest.java
@@ -32,11 +32,13 @@ import io.mindmaps.core.model.RoleType;
 import io.mindmaps.factory.MindmapsClient;
 import io.mindmaps.postprocessing.Cache;
 import io.mindmaps.util.ConfigProperties;
+import org.apache.hadoop.hdfs.DFSClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Enumeration;
 import java.util.Properties;
 
 import static com.jayway.restassured.RestAssured.delete;
@@ -45,7 +47,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class CommitLogControllerTest {
-    private Properties prop = new Properties();
     private Cache cache;
 
     @BeforeClass
@@ -53,18 +54,15 @@ public class CommitLogControllerTest {
         // Disable horrid cassandra logs
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
     }
 
     @Before
     public void setUp() throws Exception {
         new CommitLogController();
         new GraphFactoryController();
-        try {
-            prop.load(ImportControllerTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        Util.setRestAssuredBaseURI(prop);
+        Util.setRestAssuredBaseURI(ConfigProperties.getInstance().getProperties());
+
         cache = Cache.getInstance();
 
         String commitLog = "{\n" +
@@ -84,12 +82,12 @@ public class CommitLogControllerTest {
     }
 
     @After
-    public void takeDown(){
+    public void takeDown() {
         cache.getCastingJobs().clear();
     }
 
     @Test
-    public void testControllerWorking(){
+    public void testControllerWorking() {
         assertEquals(4, cache.getCastingJobs().values().iterator().next().size());
     }
 
@@ -132,7 +130,7 @@ public class CommitLogControllerTest {
     }
 
     @Test
-    public void testDeleteController(){
+    public void testDeleteController() {
         assertEquals(4, cache.getCastingJobs().values().iterator().next().size());
 
         delete(RESTUtil.WebPath.COMMIT_LOG_URI + "?" + RESTUtil.Request.GRAPH_NAME_PARAM + "=" + "test").

--- a/mindmaps-engine/src/test/java/io/mindmaps/api/GraphFactoryControllerTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/api/GraphFactoryControllerTest.java
@@ -31,8 +31,6 @@ import io.mindmaps.util.ConfigProperties;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Properties;
-
 import static com.jayway.restassured.RestAssured.get;
 import static io.mindmaps.constants.RESTUtil.Request.GRAPH_CONFIG_PARAM;
 import static io.mindmaps.constants.RESTUtil.WebPath.GRAPH_FACTORY_URI;
@@ -41,19 +39,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 public class GraphFactoryControllerTest {
-    private Properties prop = new Properties();
-
     @Before
     public void setUp() throws Exception {
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
+
         new GraphFactoryController();
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
-        try {
-            prop.load(ImportControllerTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        Util.setRestAssuredBaseURI(prop);
+        Util.setRestAssuredBaseURI(ConfigProperties.getInstance().getProperties());
+
     }
 
     @Test

--- a/mindmaps-engine/src/test/java/io/mindmaps/api/ImportControllerTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/api/ImportControllerTest.java
@@ -18,12 +18,12 @@
 
 package io.mindmaps.api;
 
-import io.mindmaps.core.implementation.exception.MindmapsValidationException;
-import io.mindmaps.util.ConfigProperties;
-import io.mindmaps.factory.GraphFactory;
-import org.junit.*;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import io.mindmaps.core.implementation.exception.MindmapsValidationException;
+import io.mindmaps.factory.GraphFactory;
+import io.mindmaps.util.ConfigProperties;
+import org.junit.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +32,6 @@ import java.util.Properties;
 public class ImportControllerTest {
 
     ImportController importer;
-    Properties prop = new Properties();
     String graphName;
 
     @BeforeClass
@@ -40,16 +39,12 @@ public class ImportControllerTest {
         // Disable horrid cassandra logs
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
     }
 
     @Before
     public void setUp() throws Exception {
-        try {
-            prop.load(ImportControllerTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        graphName = prop.getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+        graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
         importer = new ImportController(graphName);
         new CommitLogController();
 

--- a/mindmaps-engine/src/test/java/io/mindmaps/api/RemoteShellControllerTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/api/RemoteShellControllerTest.java
@@ -38,27 +38,26 @@ import static org.junit.Assert.assertTrue;
 
 public class RemoteShellControllerTest {
 
-    Properties prop = new Properties();
     String graphName;
 
 
     @Before
     public void setUp() throws Exception {
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
+
         new RemoteShellController();
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
-        try {
-            prop.load(VisualiserControllerTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        graphName = prop.getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+
+        graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
         MindmapsGraph graph = GraphFactory.getInstance().getGraph(graphName);
         MindmapsTransaction transaction = graph.getTransaction();
+
         EntityType man = transaction.putEntityType("Man");
         transaction.putEntity("actor-123", man).setValue("Al Pacino");
         transaction.commit();
-        Util.setRestAssuredBaseURI(prop);
+
+        Util.setRestAssuredBaseURI(ConfigProperties.getInstance().getProperties());
     }
 
     @Test

--- a/mindmaps-engine/src/test/java/io/mindmaps/api/TransactionControllerTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/api/TransactionControllerTest.java
@@ -40,27 +40,24 @@ import static org.junit.Assert.assertTrue;
 
 public class TransactionControllerTest {
 
-    Properties prop = new Properties();
     String graphName;
 
 
     @Before
     public void setUp() throws Exception {
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
+
         new TransactionController();
         new CommitLogController();
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
-        try {
-            prop.load(VisualiserControllerTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        graphName = prop.getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+
+        graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
         MindmapsGraph graph = GraphFactory.getInstance().getGraph(graphName);
         MindmapsTransaction transaction = graph.getTransaction();
         transaction.putEntityType("Man");
         transaction.commit();
-        Util.setRestAssuredBaseURI(prop);
+        Util.setRestAssuredBaseURI(ConfigProperties.getInstance().getProperties());
     }
 
     @Test

--- a/mindmaps-engine/src/test/java/io/mindmaps/loader/BlockingLoaderTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/loader/BlockingLoaderTest.java
@@ -35,13 +35,11 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import static io.mindmaps.graql.Graql.insert;
 
 public class BlockingLoaderTest {
 
-    Properties prop = new Properties();
     String graphName;
     BlockingLoader loader;
     private final org.slf4j.Logger LOG = LoggerFactory.getLogger(BlockingLoaderTest.class);
@@ -52,16 +50,14 @@ public class BlockingLoaderTest {
         // Disable horrid cassandra logs
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
+
     }
 
     @Before
     public void setUp() throws Exception {
-        try {
-            prop.load(BlockingLoaderTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        graphName = prop.getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+
+        graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
         loader = new BlockingLoader(graphName);
         new CommitLogController();
     }

--- a/mindmaps-engine/src/test/java/io/mindmaps/loader/DistributedLoaderTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/loader/DistributedLoaderTest.java
@@ -20,10 +20,10 @@ package io.mindmaps.loader;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import io.mindmaps.MindmapsTransaction;
 import io.mindmaps.api.CommitLogController;
 import io.mindmaps.api.TransactionController;
 import io.mindmaps.core.MindmapsGraph;
-import io.mindmaps.MindmapsTransaction;
 import io.mindmaps.core.implementation.exception.MindmapsValidationException;
 import io.mindmaps.factory.GraphFactory;
 import io.mindmaps.graql.Graql;
@@ -41,7 +41,6 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -52,23 +51,18 @@ public class DistributedLoaderTest {
 
     private MindmapsGraph graph;
 
-    private Properties prop = new Properties();
     private DistributedLoader loader;
 
     @Before
     public void setUp() throws Exception {
         LOG.setLevel(Level.INFO);
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
 
         // set up engine
         new TransactionController();
         new CommitLogController();
 
-        try {
-            prop.load(DistributedLoaderTest.class.getClassLoader().getResourceAsStream(ConfigProperties.CONFIG_TEST_FILE));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        String graphName = prop.getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+        String graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
 
         loader = new DistributedLoader(graphName, Collections.singletonList("localhost"));
         graph = GraphFactory.getInstance().getGraph(graphName);
@@ -109,7 +103,7 @@ public class DistributedLoaderTest {
         loader.waitToFinish();
     }
 
-    private void loadOntologyFromFile(File file){
+    private void loadOntologyFromFile(File file) {
         List<Var> ontologyBatch = new ArrayList<>();
 
         LOG.info("Loading new ontology .. ");
@@ -123,7 +117,7 @@ public class DistributedLoaderTest {
             Graql.withTransaction(transaction).insert(ontologyBatch).execute();
             transaction.commit();
 
-        } catch (FileNotFoundException|MindmapsValidationException e) {
+        } catch (FileNotFoundException | MindmapsValidationException e) {
             throw new RuntimeException(e);
         }
 
@@ -131,7 +125,7 @@ public class DistributedLoaderTest {
     }
 
     @After
-    public void cleanGraph(){
+    public void cleanGraph() {
         graph.clear();
     }
 }

--- a/mindmaps-engine/src/test/java/io/mindmaps/postprocessing/BackgroundTasksTest.java
+++ b/mindmaps-engine/src/test/java/io/mindmaps/postprocessing/BackgroundTasksTest.java
@@ -29,6 +29,7 @@ import io.mindmaps.core.implementation.AbstractMindmapsGraph;
 import io.mindmaps.core.implementation.MindmapsTransactionImpl;
 import io.mindmaps.core.model.*;
 import io.mindmaps.factory.MindmapsClient;
+import io.mindmaps.util.ConfigProperties;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -48,6 +49,8 @@ public class BackgroundTasksTest {
         // Disable horrid cassandra logs
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.INFO);
+        System.setProperty(ConfigProperties.CONFIG_FILE_SYSTEM_PROPERTY,ConfigProperties.TEST_CONFIG_FILE);
+
     }
 
     @Before

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
         <jinjava.version>2.1.0</jinjava.version>
         <airline.version>0.6</airline.version>
         <antlr4.visitor>true</antlr4.visitor>
-        <swagger.version>1.5.0</swagger.version>
+        <swagger.version>1.5.8</swagger.version>
+        <mjson.version>1.3</mjson.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
New changes to Engine:
    + new assets folder
    + spark java now support dynamically changing static files in the assets folder
    + HAL builder code has been refactored. Not complete yet.
    + application.properties became mindmaps-engine.properties
    + added mindmaps-engine-test.properties
    + new mindmaps-engine.properties is read on run-time and not compile-time
    + new logs folder
    + added 2 JVM params: mindmaps.dir and mindmaps.conf to give possibility
      to set working dir and config file.
    + moved MindmapsEngineServer inside io.mindmaps