### PR TITLE
Only use reasoner if there are rules defined in the graph

### DIFF
--- a/mindmaps-graql-shell/src/main/java/io/mindmaps/graql/GraqlShell.java
+++ b/mindmaps-graql-shell/src/main/java/io/mindmaps/graql/GraqlShell.java
@@ -321,8 +321,11 @@ public class GraqlShell implements AutoCloseable {
     }
 
     private void printMatchQuery(MatchQueryPrinter matchQuery, boolean setLimit) {
-        // Expand match query with reasoner
-        matchQuery.setMatchQuery(reasoner.expand(matchQuery.getMatchQuery()));
+        // Expand match query with reasoner, if there are any rules in the graph
+        // TODO: Make sure reasoner still applies things such as limit, even with rules in the graph
+        if (!reasoner.getRules().isEmpty()) {
+            matchQuery.setMatchQuery(reasoner.expand(matchQuery.getMatchQuery()));
+        }
 
         Stream<String> results = matchQuery.resultsString();
         if (setLimit) results = results.limit(100);

--- a/mindmaps-graql-shell/src/test/java/io/mindmaps/graql/shell/GraqlShellTest.java
+++ b/mindmaps-graql-shell/src/test/java/io/mindmaps/graql/shell/GraqlShellTest.java
@@ -226,6 +226,14 @@ public class GraqlShellTest {
     }
 
     @Test
+    public void testLimit() throws IOException {
+        String result = testShell("match $x isa type limit 1\n");
+
+        // Expect seven lines output - four for the license, one for the query, only one result and a new prompt
+        assertEquals(7, result.split("\n").length);
+    }
+
+    @Test
     public void fuzzTest() throws IOException {
         int repeats = 100;
         int maxCommands = 10;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/Reasoner.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/Reasoner.java
@@ -189,7 +189,7 @@ public class Reasoner {
 
     }
 
-    private Set<Rule> getRules() {
+    public Set<Rule> getRules() {
         Set<Rule> rules = new HashSet<>();
         MatchQueryDefault sq = qp.parseMatchQuery("match $x isa inference-rule;").getMatchQuery();
 


### PR DESCRIPTION
This is a temporary work-around because reasoner does not correctly apply modifiers such as "limit" to queries.