### PR TITLE
Improve ComputeQuery behaviour

### DIFF
--- a/mindmaps-core/src/main/java/io/mindmaps/graql/ComputeQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/ComputeQuery.java
@@ -18,8 +18,6 @@
 
 package io.mindmaps.graql;
 
-import io.mindmaps.MindmapsGraph;
-
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -30,6 +28,6 @@ public interface ComputeQuery {
     /**
      * Perform OLAP computation.
      */
-    Object execute(MindmapsGraph graph) throws ExecutionException, InterruptedException;
+    Object execute() throws ExecutionException, InterruptedException;
 
 }

--- a/mindmaps-engine/src/main/java/io/mindmaps/engine/session/GraqlSession.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/engine/session/GraqlSession.java
@@ -19,12 +19,10 @@
 package io.mindmaps.engine.session;
 
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.exception.ConceptException;
-import io.mindmaps.exception.MindmapsValidationException;
-import io.mindmaps.exception.InvalidConceptTypeException;
-import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.Instance;
+import io.mindmaps.exception.ConceptException;
+import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.graql.*;
 import io.mindmaps.graql.internal.parser.ANSI;
 import io.mindmaps.graql.internal.parser.MatchQueryPrinter;
@@ -100,7 +98,7 @@ class GraqlSession {
                 } else if (query instanceof AggregateQuery) {
                     results = streamAggregateQuery((AggregateQuery) query);
                 } else if (query instanceof ComputeQuery) {
-                    Object computeResult = ((ComputeQuery) query).execute(this.graph);
+                    Object computeResult = ((ComputeQuery) query).execute();
                     if (computeResult instanceof Map) {
                         Map<Instance, ?> map = (Map<Instance, ?>) computeResult;
                         results = map.entrySet().stream().map(e -> e.getKey().getId() + "\t" + e.getValue());

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilder.java
@@ -24,10 +24,12 @@ import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.query.Patterns;
 import io.mindmaps.graql.internal.query.Queries;
 import io.mindmaps.graql.internal.util.AdminConverter;
+import io.mindmaps.util.ErrorMessage;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A starting point for creating queries.
@@ -81,6 +83,16 @@ public class QueryBuilder {
     public InsertQuery insert(Collection<? extends Var> vars) {
         ImmutableSet<VarAdmin> varAdmins = ImmutableSet.copyOf(AdminConverter.getVarAdmins(vars));
         return Queries.insert(varAdmins, graph);
+    }
+
+    public ComputeQuery compute(String computeMethod) {
+        MindmapsGraph theGraph = graph.orElseThrow(() -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage()));
+        return Queries.compute(theGraph, computeMethod);
+    }
+
+    public ComputeQuery compute(String computeMethod, Set<String> typeIds) {
+        MindmapsGraph theGraph = graph.orElseThrow(() -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage()));
+        return Queries.compute(theGraph, computeMethod, typeIds);
     }
 
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
@@ -19,31 +19,14 @@
 package io.mindmaps.graql.internal.parser;
 
 import com.google.common.collect.ImmutableMap;
-import io.mindmaps.graql.internal.query.Queries;
-import io.mindmaps.graql.internal.util.StringConverter;
 import io.mindmaps.concept.ResourceType;
-import io.mindmaps.graql.Aggregate;
-import io.mindmaps.graql.AskQuery;
-import io.mindmaps.graql.ComputeQuery;
-import io.mindmaps.graql.DeleteQuery;
-import io.mindmaps.graql.Graql;
-import io.mindmaps.graql.InsertQuery;
-import io.mindmaps.graql.MatchQuery;
-import io.mindmaps.graql.NamedAggregate;
-import io.mindmaps.graql.Pattern;
-import io.mindmaps.graql.QueryBuilder;
-import io.mindmaps.graql.ValuePredicate;
-import io.mindmaps.graql.Var;
+import io.mindmaps.graql.*;
+import io.mindmaps.graql.internal.util.StringConverter;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -142,9 +125,9 @@ public class QueryVisitor extends GraqlBaseVisitor {
 
         if (ctx.subgraph() != null) {
             Set<String> typeIds = visitSubgraph(ctx.subgraph());
-            return Queries.compute(computeMethod, typeIds);
+            return queryBuilder.compute(computeMethod, typeIds);
         } else {
-            return Queries.compute(computeMethod);
+            return queryBuilder.compute(computeMethod);
         }
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
@@ -32,21 +32,24 @@ import static java.util.stream.Collectors.toSet;
 
 class ComputeQueryImpl implements ComputeQuery {
 
+    private final MindmapsGraph graph;
     private Optional<Set<String>> typeIds;
     private final String computeMethod;
 
-    ComputeQueryImpl(String computeMethod) {
+    ComputeQueryImpl(MindmapsGraph graph, String computeMethod) {
+        this.graph = graph;
         this.computeMethod = computeMethod;
         this.typeIds = Optional.empty();
     }
 
-    ComputeQueryImpl(String computeMethod, Set<String> typeIds) {
+    ComputeQueryImpl(MindmapsGraph graph, String computeMethod, Set<String> typeIds) {
+        this.graph = graph;
         this.computeMethod = computeMethod;
         this.typeIds = Optional.of(typeIds);
     }
 
     @Override
-    public Object execute(MindmapsGraph graph) throws ExecutionException, InterruptedException {
+    public Object execute() throws ExecutionException, InterruptedException {
         String keyspace = graph.getKeyspace();
 
         Analytics analytics = typeIds.map(ids -> {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 class ComputeQueryImpl implements ComputeQuery {
@@ -78,7 +79,8 @@ class ComputeQueryImpl implements ComputeQuery {
 
     @Override
     public String toString() {
-        return "compute "+computeMethod+"()";
+        String subtypes = typeIds.map(types -> " in " + types.stream().collect(joining(", "))).orElse("");
+        return "compute " + computeMethod + subtypes;
     }
 
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
@@ -74,12 +74,12 @@ public class Queries {
         return new DeleteQueryImpl(deleters, matchQuery);
     }
 
-    public static ComputeQuery compute(String computeMethod) {
-        return new ComputeQueryImpl(computeMethod);
+    public static ComputeQuery compute(MindmapsGraph graph, String computeMethod) {
+        return new ComputeQueryImpl(graph, computeMethod);
     }
 
-    public static ComputeQuery compute(String computeMethod, Set<String> typeIds) {
-        return new ComputeQueryImpl(computeMethod, typeIds);
+    public static ComputeQuery compute(MindmapsGraph graph, String computeMethod, Set<String> typeIds) {
+        return new ComputeQueryImpl(graph, computeMethod, typeIds);
     }
 
     public static <T> AggregateQuery<T> aggregate(MatchQueryAdmin matchQuery, Aggregate<? super Map<String, Concept>, T> aggregate) {

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryToStringTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryToStringTest.java
@@ -18,23 +18,19 @@
 
 package io.mindmaps.graql.parser;
 
+import com.google.common.collect.Sets;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.ResourceType;
 import io.mindmaps.example.MovieGraphFactory;
 import io.mindmaps.factory.MindmapsTestGraphFactory;
+import io.mindmaps.graql.ComputeQuery;
 import io.mindmaps.graql.MatchQuery;
 import io.mindmaps.graql.QueryBuilder;
 import io.mindmaps.graql.QueryParser;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.mindmaps.graql.Graql.id;
-import static io.mindmaps.graql.Graql.lte;
-import static io.mindmaps.graql.Graql.match;
-import static io.mindmaps.graql.Graql.neq;
-import static io.mindmaps.graql.Graql.or;
-import static io.mindmaps.graql.Graql.var;
-import static io.mindmaps.graql.Graql.withGraph;
+import static io.mindmaps.graql.Graql.*;
 import static org.junit.Assert.assertEquals;
 
 public class QueryToStringTest {
@@ -142,6 +138,17 @@ public class QueryToStringTest {
     @Test
     public void testHasResource() {
         assertEquals("insert $x has-resource thingy;", qb.insert(var("x").hasResource("thingy")).toString());
+    }
+
+    @Test
+    public void testComputeQueryToString() {
+        assertEquals("compute count", qb.compute("count").toString());
+    }
+
+    @Test
+    public void testComputeQuerySubgraphToString() {
+        ComputeQuery query = qb.compute("degrees", Sets.newHashSet("movie", "person"));
+        assertEquals("compute degrees in movie, person", query.toString());
     }
 
     @Test(expected=UnsupportedOperationException.class)

--- a/mindmaps-test/src/test/java/io/mindmaps/graql/internal/analytics/GraqlTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/graql/internal/analytics/GraqlTest.java
@@ -81,7 +81,7 @@ public class GraqlTest {
                 or(var("y").isa("entity-type"), var("y").isa("resource-type"), var("y").isa("relation-type"))
         ).stream().count();
 
-        long computeCount = ((Long) ((ComputeQuery) qp.parseQuery("compute count")).execute(graph));
+        long computeCount = ((Long) ((ComputeQuery) qp.parseQuery("compute count")).execute());
 
         assertEquals(graqlCount, computeCount);
         assertEquals(3L, computeCount);
@@ -97,7 +97,7 @@ public class GraqlTest {
         graph.putEntity("3", anotherThing);
         graph.commit();
 
-        long computeCount = ((Long) ((ComputeQuery) qp.parseQuery("compute count in thing, thing")).execute(graph));
+        long computeCount = ((Long) ((ComputeQuery) qp.parseQuery("compute count in thing, thing")).execute());
         assertEquals(2, computeCount);
     }
 
@@ -125,7 +125,7 @@ public class GraqlTest {
         graph.commit();
 
         // compute degrees
-        Map<Instance, Long> degrees = ((Map) ((ComputeQuery) qp.parseQuery("compute degrees")).execute(graph));
+        Map<Instance, Long> degrees = ((Map) ((ComputeQuery) qp.parseQuery("compute degrees")).execute());
 
         // assert degrees are correct
         instantiateSimpleConcepts();
@@ -186,7 +186,7 @@ public class GraqlTest {
         graph.commit();
 
         // compute degrees
-        ((ComputeQuery) qp.parseQuery("compute degreesAndPersist")).execute(graph);
+        ((ComputeQuery) qp.parseQuery("compute degreesAndPersist")).execute();
 
         // assert persisted degrees are correct
         instantiateSimpleConcepts();


### PR DESCRIPTION
- Add `QueryBuilder::compute` method
- Remove `graph` parameter from `ComputeQuery::execute`
- Fix `ComputeQuery::toString` to handle subgraph parameters correctly