### PR TITLE
Introduce new Query interface

### DIFF
--- a/mindmaps-core/src/main/java/io/mindmaps/graql/AggregateQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/AggregateQuery.java
@@ -19,10 +19,15 @@
 
 package io.mindmaps.graql;
 
+import io.mindmaps.MindmapsGraph;
+
 /**
  * An aggregate query produced from a {@link MatchQuery}.
  *
  * @param <T> the type of the result of the aggregate query
  */
 public interface AggregateQuery<T> extends Query<T> {
+
+    @Override
+    AggregateQuery<T> withGraph(MindmapsGraph graph);
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/AggregateQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/AggregateQuery.java
@@ -24,11 +24,5 @@ package io.mindmaps.graql;
  *
  * @param <T> the type of the result of the aggregate query
  */
-public interface AggregateQuery<T> {
-
-    /**
-     * Execute the aggregate query.
-     * @return the result of the aggregate query
-     */
-    T execute();
+public interface AggregateQuery<T> extends Query<T> {
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/AskQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/AskQuery.java
@@ -26,11 +26,7 @@ import io.mindmaps.graql.admin.AskQueryAdmin;
  * <p>
  * An {@code AskQuery} is created from a {@code MatchQuery}, which describes what patterns it should find.
  */
-public interface AskQuery {
-    /**
-     * @return whether the given patterns can be found in the graph
-     */
-    boolean execute();
+public interface AskQuery extends Query<Boolean> {
 
     /**
      * @param graph the graph to execute the query on

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/ComputeQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/ComputeQuery.java
@@ -18,8 +18,13 @@
 
 package io.mindmaps.graql;
 
+import io.mindmaps.MindmapsGraph;
+
 /**
  * A query that triggers an OLAP computation on a graph.
  */
 public interface ComputeQuery extends Query<Object> {
+
+    @Override
+    ComputeQuery withGraph(MindmapsGraph graph);
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/DeleteQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/DeleteQuery.java
@@ -31,12 +31,7 @@ import io.mindmaps.graql.admin.DeleteQueryAdmin;
  * are provided, then the delete query will delete the concept bound to each given variable name. If property flags
  * are provided, e.g. {@code var("x").has("name")} then only those properties are deleted.
  */
-public interface DeleteQuery {
-
-    /**
-     * Execute the delete query
-     */
-    void execute();
+public interface DeleteQuery extends Query<Void> {
 
     /**
      * @param graph the graph to execute the query on

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/InsertQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/InsertQuery.java
@@ -32,18 +32,13 @@ import io.mindmaps.graql.admin.InsertQueryAdmin;
  * When built from a {@code MatchQuery}, the insert query will execute for each result of the {@code MatchQuery},
  * where variable names in the {@code InsertQuery} are bound to the concept in the result of the {@code MatchQuery}.
  */
-public interface InsertQuery extends Streamable<Concept> {
+public interface InsertQuery extends Query<Void>, Streamable<Concept> {
 
     /**
      * @param graph the graph to execute the query on
      * @return a new InsertQuery with the graph set
      */
     InsertQuery withGraph(MindmapsGraph graph);
-
-    /**
-     * Execute the insert query
-     */
-    void execute();
 
     /**
      * @return admin instance for inspecting and manipulating this query

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/MatchQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/MatchQuery.java
@@ -26,6 +26,8 @@ import io.mindmaps.graql.admin.MatchQueryAdmin;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
+
 /**
  * a query used for finding data in a graph that matches the given patterns.
  * <p>
@@ -34,7 +36,12 @@ import java.util.stream.Stream;
  * <p>
  * Each matching subgraph will produce a map, where keys are variable names and values are concepts in the graph.
  */
-public interface MatchQuery extends Streamable<Map<String, Concept>> {
+public interface MatchQuery extends Query<List<Map<String, Concept>>>, Streamable<Map<String, Concept>> {
+
+    @Override
+    default List<Map<String, Concept>> execute() {
+        return stream().collect(toList());
+    }
 
     /**
      * @param names an array of variable names to select

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
@@ -20,6 +20,8 @@ package io.mindmaps.graql;
 
 import io.mindmaps.MindmapsGraph;
 
+import java.util.stream.Stream;
+
 public interface Query<T> {
 
     /**
@@ -30,4 +32,13 @@ public interface Query<T> {
 
     T execute();
 
+    /**
+     * Execute the query and return a human-readable stream of results
+     */
+    Stream<String> resultsString();
+
+    /**
+     * Whether this query will modify the graph
+     */
+    boolean isReadOnly();
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
@@ -18,8 +18,8 @@
 
 package io.mindmaps.graql;
 
-/**
- * A query that triggers an OLAP computation on a graph.
- */
-public interface ComputeQuery extends Query<Object> {
+public interface Query<T> {
+
+    T execute();
+
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/Query.java
@@ -18,7 +18,15 @@
 
 package io.mindmaps.graql;
 
+import io.mindmaps.MindmapsGraph;
+
 public interface Query<T> {
+
+    /**
+     * @param graph the graph to execute the query on
+     * @return a new query with the graph set
+     */
+    Query<T> withGraph(MindmapsGraph graph);
 
     T execute();
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryParser.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryParser.java
@@ -115,7 +115,7 @@ public class QueryParser {
      * @return
      * a query, the type will depend on the type of query.
      */
-    public Object parseQuery(String queryString) {
+    public Query<?> parseQuery(String queryString) {
         return parseQueryFragment(GraqlParser::queryEOF, QueryVisitor::visitQueryEOF, queryString);
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
@@ -59,6 +59,11 @@ public class MatchQueryPrinter implements Query<Stream<String>> {
      * @return a stream of strings, where each string represents a result
      */
     public Stream<String> execute() {
+        return resultsString();
+    }
+
+    @Override
+    public Stream<String> resultsString() {
         return matchQuery.stream().map(results -> {
             StringBuilder str = new StringBuilder();
 
@@ -72,6 +77,11 @@ public class MatchQueryPrinter implements Query<Stream<String>> {
 
             return str.toString();
         });
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
     }
 
     private List<Getter> getGetters(String name) {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
@@ -18,8 +18,10 @@
 
 package io.mindmaps.graql.internal.parser;
 
+import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.graql.MatchQuery;
+import io.mindmaps.graql.Query;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,7 +31,7 @@ import java.util.stream.Stream;
 /**
  * A printer for a MatchQuery, that uses a map of Getters to decide what information to print
  */
-public class MatchQueryPrinter {
+public class MatchQueryPrinter implements Query<Stream<String>> {
 
     private MatchQuery matchQuery;
     private final Map<String, List<Getter>> getters;
@@ -56,7 +58,7 @@ public class MatchQueryPrinter {
     /**
      * @return a stream of strings, where each string represents a result
      */
-    public Stream<String> resultsString() {
+    public Stream<String> execute() {
         return matchQuery.stream().map(results -> {
             StringBuilder str = new StringBuilder();
 
@@ -83,5 +85,10 @@ public class MatchQueryPrinter {
         }
 
         return getterList;
+    }
+
+    @Override
+    public Query<Stream<String>> withGraph(MindmapsGraph graph) {
+        return new MatchQueryPrinter(matchQuery.withGraph(graph), getters);
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
@@ -50,8 +50,8 @@ public class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Object visitQueryEOF(GraqlParser.QueryEOFContext ctx) {
-        return visitQuery(ctx.query());
+    public Query<?> visitQueryEOF(GraqlParser.QueryEOFContext ctx) {
+        return (Query<?>) visitQuery(ctx.query());
     }
 
     @Override
@@ -75,12 +75,12 @@ public class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Object visitComputeEOF(GraqlParser.ComputeEOFContext ctx) {
+    public ComputeQuery visitComputeEOF(GraqlParser.ComputeEOFContext ctx) {
         return visitComputeQuery(ctx.computeQuery());
     }
 
     @Override
-    public Object visitAggregateEOF(GraqlParser.AggregateEOFContext ctx) {
+    public AggregateQuery<?> visitAggregateEOF(GraqlParser.AggregateEOFContext ctx) {
         return visitAggregateQuery(ctx.aggregateQuery());
     }
 
@@ -137,7 +137,7 @@ public class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Object visitAggregateQuery(GraqlParser.AggregateQueryContext ctx) {
+    public AggregateQuery<?> visitAggregateQuery(GraqlParser.AggregateQueryContext ctx) {
         Aggregate aggregate = visitAggregate(ctx.aggregate());
         MatchQuery matchQuery = visitMatchQuery(ctx.matchQuery()).getMatchQuery();
         return matchQuery.aggregate(aggregate);

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AggregateQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AggregateQueryImpl.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.internal.query;
 
+import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.graql.Aggregate;
 import io.mindmaps.graql.AggregateQuery;
@@ -37,6 +38,11 @@ class AggregateQueryImpl<T> implements AggregateQuery<T> {
     AggregateQueryImpl(MatchQueryAdmin matchQuery, Aggregate<? super Map<String, Concept>, T> aggregate) {
         this.matchQuery = matchQuery;
         this.aggregate = aggregate;
+    }
+
+    @Override
+    public AggregateQuery<T> withGraph(MindmapsGraph graph) {
+        return new AggregateQueryImpl<>(matchQuery.withGraph(graph).admin(), aggregate);
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AggregateQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AggregateQueryImpl.java
@@ -25,6 +25,7 @@ import io.mindmaps.graql.AggregateQuery;
 import io.mindmaps.graql.admin.MatchQueryAdmin;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Implementation of AggregateQuery
@@ -48,6 +49,17 @@ class AggregateQueryImpl<T> implements AggregateQuery<T> {
     @Override
     public T execute() {
         return aggregate.apply(matchQuery.stream());
+    }
+
+    @Override
+    public Stream<String> resultsString() {
+        return Stream.of(execute().toString());
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        // An aggregate query may modify the graph if using a user-defined aggregate method
+        return false;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
@@ -22,6 +22,9 @@ import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.AskQuery;
 import io.mindmaps.graql.MatchQuery;
 import io.mindmaps.graql.admin.AskQueryAdmin;
+import io.mindmaps.graql.internal.parser.ANSI;
+
+import java.util.stream.Stream;
 
 /**
  * An AskQuery to check if a given pattern matches anywhere in the graph
@@ -40,6 +43,20 @@ class AskQueryImpl implements AskQueryAdmin {
     @Override
     public Boolean execute() {
         return matchQuery.iterator().hasNext();
+    }
+
+    @Override
+    public Stream<String> resultsString() {
+        if (execute()) {
+            return Stream.of(ANSI.color("True", ANSI.GREEN));
+        } else {
+            return Stream.of(ANSI.color("False", ANSI.RED));
+        }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
@@ -38,7 +38,7 @@ class AskQueryImpl implements AskQueryAdmin {
     }
 
     @Override
-    public boolean execute() {
+    public Boolean execute() {
         return matchQuery.iterator().hasNext();
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
@@ -50,7 +50,7 @@ class ComputeQueryImpl implements ComputeQuery {
     }
 
     @Override
-    public Object execute() throws ExecutionException, InterruptedException {
+    public Object execute() {
         String keyspace = graph.getKeyspace();
 
         Analytics analytics = typeIds.map(ids -> {
@@ -68,7 +68,11 @@ class ComputeQueryImpl implements ComputeQuery {
                 return analytics.degrees();
             }
             case "degreesAndPersist": {
-                analytics.degreesAndPersist();
+                try {
+                    analytics.degreesAndPersist();
+                } catch (ExecutionException | InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 return "Degrees have been persisted.";
             }
             default: {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
@@ -37,16 +37,10 @@ class ComputeQueryImpl implements ComputeQuery {
     private Optional<Set<String>> typeIds;
     private final String computeMethod;
 
-    ComputeQueryImpl(MindmapsGraph graph, String computeMethod) {
+    ComputeQueryImpl(MindmapsGraph graph, String computeMethod, Optional<Set<String>> typeIds) {
         this.graph = graph;
         this.computeMethod = computeMethod;
-        this.typeIds = Optional.empty();
-    }
-
-    ComputeQueryImpl(MindmapsGraph graph, String computeMethod, Set<String> typeIds) {
-        this.graph = graph;
-        this.computeMethod = computeMethod;
-        this.typeIds = Optional.of(typeIds);
+        this.typeIds = typeIds;
     }
 
     @Override
@@ -88,4 +82,8 @@ class ComputeQueryImpl implements ComputeQuery {
         return "compute " + computeMethod + subtypes;
     }
 
+    @Override
+    public ComputeQuery withGraph(MindmapsGraph graph) {
+        return new ComputeQueryImpl(graph, computeMethod, typeIds);
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ComputeQueryImpl.java
@@ -19,14 +19,17 @@
 package io.mindmaps.graql.internal.query;
 
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.util.ErrorMessage;
+import io.mindmaps.concept.Instance;
 import io.mindmaps.concept.Type;
 import io.mindmaps.graql.ComputeQuery;
 import io.mindmaps.graql.internal.analytics.Analytics;
+import io.mindmaps.util.ErrorMessage;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
@@ -74,6 +77,23 @@ class ComputeQueryImpl implements ComputeQuery {
             }
         }
 
+    }
+
+    @Override
+    public Stream<String> resultsString() {
+        Object computeResult = execute();
+        if (computeResult instanceof Map) {
+            Map<Instance, ?> map = (Map<Instance, ?>) computeResult;
+            return map.entrySet().stream().map(e -> e.getKey().getId() + "\t" + e.getValue());
+        } else {
+            return Stream.of(computeResult.toString());
+        }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        // A compute query may modify the graph based on which method is being used
+        return false;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
@@ -62,8 +62,9 @@ class DeleteQueryImpl implements DeleteQueryAdmin {
     }
 
     @Override
-    public void execute() {
+    public Void execute() {
         matchQuery.forEach(results -> results.forEach(this::deleteResult));
+        return null;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A DeleteQuery that will execute deletions for every result of a MatchQuery
@@ -65,6 +66,17 @@ class DeleteQueryImpl implements DeleteQueryAdmin {
     public Void execute() {
         matchQuery.forEach(results -> results.forEach(this::deleteResult));
         return null;
+    }
+
+    @Override
+    public Stream<String> resultsString() {
+        execute();
+        return Stream.empty();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
@@ -88,6 +88,16 @@ class InsertQueryImpl implements InsertQueryAdmin {
     }
 
     @Override
+    public Stream<String> resultsString() {
+        return stream().map(Concept::getId);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     public Stream<Concept> stream() {
         MindmapsGraph theGraph =
                 getGraph().orElseThrow(() -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage()));

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
@@ -81,9 +81,10 @@ class InsertQueryImpl implements InsertQueryAdmin {
     }
 
     @Override
-    public void execute() {
+    public Void execute() {
         // Do nothing, just execute whole stream
         stream().forEach(c -> {});
+        return null;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
@@ -75,11 +75,11 @@ public class Queries {
     }
 
     public static ComputeQuery compute(MindmapsGraph graph, String computeMethod) {
-        return new ComputeQueryImpl(graph, computeMethod);
+        return new ComputeQueryImpl(graph, computeMethod, Optional.empty());
     }
 
     public static ComputeQuery compute(MindmapsGraph graph, String computeMethod, Set<String> typeIds) {
-        return new ComputeQueryImpl(graph, computeMethod, typeIds);
+        return new ComputeQueryImpl(graph, computeMethod, Optional.of(typeIds));
     }
 
     public static <T> AggregateQuery<T> aggregate(MatchQueryAdmin matchQuery, Aggregate<? super Map<String, Concept>, T> aggregate) {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
@@ -36,6 +36,16 @@ import static java.util.stream.Collectors.toList;
 @SuppressWarnings("UnusedReturnValue")
 interface MatchQueryInternal extends MatchQueryAdmin {
 
+    @Override
+    default Stream<String> resultsString() {
+        return stream().map(Object::toString);
+    }
+
+    @Override
+    default boolean isReadOnly() {
+        return true;
+    }
+
     /**
      * Execute the query using the given graph.
      * @param graph the graph to use to execute the query


### PR DESCRIPTION
The `Query` interface is shared between all query types and contains any common methods, such as `execute` and `resultString`.