### PR TITLE
Allow referring to a resource with a variable name

### DIFF
--- a/mindmaps-core/src/main/java/io/mindmaps/graql/Var.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/Var.java
@@ -85,6 +85,15 @@ public interface Var extends Pattern {
     Var has(String type, ValuePredicate predicate);
 
     /**
+     * the variable must have a resource or name of the given type that matches the given predicate
+     *
+     * @param type a resource type in the ontology
+     * @param var a variable representing a resource
+     * @return this
+     */
+    Var has(String type, Var var);
+
+    /**
      * @param type a concept type id that the variable must be of this type
      * @return this
      */

--- a/mindmaps-core/src/main/java/io/mindmaps/graql/admin/VarAdmin.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/admin/VarAdmin.java
@@ -165,14 +165,14 @@ public interface VarAdmin extends PatternAdmin, Var {
     Optional<String> getRhs();
 
     /**
+     * @return all resources that this instance must have
+     */
+    Set<VarAdmin> getResources();
+
+    /**
      * @return all predicates on resources of this variable (where the key is the resource type)
      */
     Map<VarAdmin, Set<ValuePredicateAdmin>> getResourcePredicates();
-
-    /**
-     * @return all values of resources on this variable (where the key is the resource type)
-     */
-    Map<VarAdmin, Set<?>> getResourceEqualsPredicates();
 
     /**
      * @return whether this variable uses any predicate that is not equality

--- a/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
+++ b/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
@@ -50,7 +50,7 @@ property       : edge
                | propLhs
                | propRhs
                | propHasFlag
-               | propHasPred
+               | propHasFull
                | propResource
                | propRel
                | isAbstract
@@ -86,7 +86,7 @@ propRhs        : 'rhs' '{' query '}' ;
 
 propHasFlag    : 'has' id ;
 propHas        : 'has' id value ;
-propHasPred    : 'has' id predicate ;
+propHasFull    : 'has' id (predicate | VARIABLE) ;
 
 propResource   : 'has-resource' variable ;
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import static io.mindmaps.graql.Graql.var;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -298,8 +299,13 @@ class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Void visitPropHasPred(GraqlParser.PropHasPredContext ctx) {
-        patterns.peek().has(visitId(ctx.id()), visitPredicate(ctx.predicate()));
+    public Void visitPropHasFull(GraqlParser.PropHasFullContext ctx) {
+        String type = visitId(ctx.id());
+        if (ctx.predicate() != null) {
+            patterns.peek().has(type, visitPredicate(ctx.predicate()));
+        } else {
+            patterns.peek().has(type, var(getVariable(ctx.VARIABLE())));
+        }
         return null;
     }
 
@@ -405,7 +411,7 @@ class QueryVisitor extends GraqlBaseVisitor {
     @Override
     public Var visitVariable(GraqlParser.VariableContext ctx) {
         if (ctx == null) {
-            return Graql.var();
+            return var();
         } else if (ctx.id() != null) {
             return Graql.id(visitId(ctx.id()));
         } else {
@@ -605,9 +611,9 @@ class QueryVisitor extends GraqlBaseVisitor {
     private Var buildVar(TerminalNode variable) {
         Var var;
         if (variable != null) {
-            var = Graql.var(getVariable(variable));
+            var = var(getVariable(variable));
         } else {
-            var = Graql.var();
+            var = var();
         }
         return var;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/DeleteQueryImpl.java
@@ -20,16 +20,16 @@ package io.mindmaps.graql.internal.query;
 
 import com.google.common.collect.ImmutableMap;
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.util.ErrorMessage;
-import io.mindmaps.exception.ConceptException;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.Resource;
+import io.mindmaps.exception.ConceptException;
 import io.mindmaps.graql.DeleteQuery;
 import io.mindmaps.graql.MatchQuery;
 import io.mindmaps.graql.admin.DeleteQueryAdmin;
 import io.mindmaps.graql.admin.MatchQueryAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.validation.DeleteQueryValidator;
+import io.mindmaps.util.ErrorMessage;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -125,7 +125,11 @@ class DeleteQueryImpl implements DeleteQueryAdmin {
                     )
             );
 
-            deleter.getResourceEqualsPredicates().forEach((type, values) -> deleteResources(id, type, values));
+            deleter.getResourcePredicates().forEach((type, predicates) -> {
+                Set<Object> values = new HashSet<>();
+                predicates.forEach(predicate -> predicate.equalsValue().ifPresent(values::add));
+                deleteResources(id, type, values);
+            });
         }
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
@@ -133,9 +133,9 @@ class InsertQueryExecutor {
     private Concept insertVarResources(VarAdmin var) {
         Concept concept = getConcept(var);
 
-        if (!var.getResourceEqualsPredicates().isEmpty()) {
+        if (!var.getResources().isEmpty()) {
             Instance instance = concept.asInstance();
-            var.getResourceEqualsPredicates().forEach((type, values) -> addResources(instance, type, values));
+            var.getResources().forEach(resource -> attachResource(instance, getConcept(resource).asResource()));
         }
 
         return concept;
@@ -376,28 +376,12 @@ class InsertQueryExecutor {
     }
 
     /**
-     * Add resources to the given instance, using the has-resource relation
-     * @param instance the instance to add resources to
-     * @param resourceType the variable representing the resource type
-     * @param values a set of values to set on the resource instances
-     * @param <D> the type of the resources
-     */
-    private <D> void addResources(Instance instance, VarAdmin resourceType, Set<D> values) {
-        // We assume the resource type has the correct datatype. If it does not, core will catch the problem
-        //noinspection unchecked
-        ResourceType<D> type = getConcept(resourceType).asResourceType();
-        values.forEach(value -> addResource(instance, type, value));
-    }
-
-    /**
      * Add a resource to the given instance, using the has-resource relation
      * @param instance the instance to add a resource to
-     * @param type the resource type
-     * @param value the value to set on the resource instance
-     * @param <D> the type of the resource
+     * @param resource the resource instance
      */
-    private <D> void addResource(Instance instance, ResourceType<D> type, D value) {
-        Resource resource = graph.putResource(value, type);
+    private void attachResource(Instance instance, Resource resource) {
+        ResourceType type = resource.type();
 
         RelationType hasResource = graph.getRelationType(GraqlType.HAS_RESOURCE.getId(type.getId()));
         RoleType hasResourceTarget = graph.getRoleType(GraqlType.HAS_RESOURCE_OWNER.getId(type.getId()));

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryParserTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryParserTest.java
@@ -470,6 +470,14 @@ public class QueryParserTest {
         qb.parseMatch("match $x is");
     }
 
+    @Test
+    public void testHasVariable() {
+        MatchQuery query = qb.parseMatch("match Godfather has tmdb-vote-count $x").getMatchQuery();
+
+        //noinspection OptionalGetWithoutIsPresent
+        assertEquals(1000L, query.get("x").findFirst().get().asResource().getValue());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testMultipleQueriesThrowsIllegalArgumentException() {
         qb.parseInsert("insert $x isa movie; insert $y isa movie").execute();

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryTest.java
@@ -439,4 +439,12 @@ public class MatchQueryTest {
         // This should work despite akos
         qb.match(var().rel("x").rel("shareholder", "y").isa("ownership")).stream().count();
     }
+
+    @Test
+    public void testHasVariable() {
+        MatchQuery query = qb.match(var().id("Godfather").has("tmdb-vote-count", var("x")));
+
+        //noinspection OptionalGetWithoutIsPresent
+        assertEquals(1000L, query.get("x").findFirst().get().asResource().getValue());
+    }
 }


### PR DESCRIPTION
e.g. `match 'The Godfather' has runtime $x`