### PR TITLE
Make ordering always operate by value, not ID

### DIFF
--- a/mindmaps-core/src/main/java/io/mindmaps/graql/MatchQuery.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/graql/MatchQuery.java
@@ -120,25 +120,6 @@ public interface MatchQuery extends Query<List<Map<String, Concept>>>, Streamabl
     MatchQuery orderBy(String varName, boolean asc);
 
     /**
-     * Order the results by a resource in ascending order
-     * @param varName the variable name to order the results by
-     * @param resourceType the resource type attached to the variable to use for ordering
-     * @return a new MatchQuery with the given ordering
-     */
-    default MatchQuery orderBy(String varName, String resourceType) {
-        return orderBy(varName, resourceType, true);
-    }
-
-    /**
-     * Order the results by a resource
-     * @param varName the variable name to order the results by
-     * @param resourceType the resource type attached to the variable to use for ordering
-     * @param asc whether to use ascending order
-     * @return a new MatchQuery with the given ordering
-     */
-    MatchQuery orderBy(String varName, String resourceType, boolean asc);
-
-    /**
      * @param graph the graph to execute the query on
      * @return a new MatchQuery with the graph set
      */

--- a/mindmaps-graph/src/main/java/io/mindmaps/example/MovieGraphFactory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/example/MovieGraphFactory.java
@@ -132,6 +132,7 @@ public class MovieGraphFactory {
                 .playsRole(director).playsRole(actor).playsRole(characterBeingPlayed);
 
         hasResource(person, gender);
+        hasResource(person, name);
         hasResource(person, realName);
 
         genre = mindmapsGraph.putEntityType("genre").playsRole(genreOfProduction);
@@ -187,15 +188,25 @@ public class MovieGraphFactory {
         putResource(chineseCoffee, releaseDate, DATE_FORMAT.parse("Sat Sep 02 00:00:00 GMT 2000").getTime());
 
         marlonBrando = putEntity(person, "Marlon Brando");
+        putResource(marlonBrando, name, "Marlon Brando");
         alPacino = putEntity(person, "Al Pacino");
+        putResource(alPacino, name, "Al Pacino");
         missPiggy = putEntity(person, "Miss Piggy");
+        putResource(missPiggy, name, "Miss Piggy");
         kermitTheFrog = putEntity(person, "Kermit The Frog");
+        putResource(kermitTheFrog, name, "Kermit The Frog");
         martinSheen = putEntity(person, "Martin Sheen");
+        putResource(martinSheen, name, "Martin Sheen");
         robertDeNiro = putEntity(person, "Robert de Niro");
+        putResource(robertDeNiro, name, "Robert de Niro");
         judeLaw = putEntity(person, "Jude Law");
+        putResource(judeLaw, name, "Jude Law");
         mirandaHeart = putEntity(person, "Miranda Heart");
+        putResource(mirandaHeart, name, "Miranda Heart");
         betteMidler = putEntity(person, "Bette Midler");
+        putResource(betteMidler, name, "Bette Midler");
         sarahJessicaParker = putEntity(person, "Sarah Jessica Parker");
+        putResource(sarahJessicaParker, name, "Sarah Jessica Parker");
 
         crime = putEntity(genre, "crime");
         putResource(crime, name, "crime");

--- a/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
+++ b/mindmaps-graql/src/main/antlr4/io/mindmaps/graql/internal/parser/Graql.g4
@@ -76,11 +76,11 @@ value          : STRING  # valueString
                ;
 
 modifiers      : (','? modifier)* ;
-modifier       : 'select' VARIABLE (',' VARIABLE)*                # modifierSelect
-               | 'limit' INTEGER                                  # modifierLimit
-               | 'offset' INTEGER                                 # modifierOffset
-               | 'distinct'                                       # modifierDistinct
-               | 'order' 'by' VARIABLE ('(' 'has' id ')')? ORDER? # modifierOrderBy
+modifier       : 'select' VARIABLE (',' VARIABLE)* # modifierSelect
+               | 'limit' INTEGER                   # modifierLimit
+               | 'offset' INTEGER                  # modifierOffset
+               | 'distinct'                        # modifierDistinct
+               | 'order' 'by' VARIABLE ORDER?      # modifierOrderBy
                ;
 
 // This rule is used for parsing streams of patterns separated by semicolons

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/QueryVisitor.java
@@ -427,19 +427,10 @@ class QueryVisitor extends GraqlBaseVisitor {
     public UnaryOperator<MatchQuery> visitModifierOrderBy(GraqlParser.ModifierOrderByContext ctx) {
         // decide which ordering method to use
         String var = getVariable(ctx.VARIABLE());
-        if (ctx.id() != null) {
-            String type = visitId(ctx.id());
-            if (ctx.ORDER() != null) {
-                return matchQuery -> matchQuery.orderBy(var, type, getOrder(ctx.ORDER()));
-            } else {
-                return matchQuery -> matchQuery.orderBy(var, type);
-            }
+        if (ctx.ORDER() != null) {
+            return matchQuery -> matchQuery.orderBy(var, getOrder(ctx.ORDER()));
         } else {
-            if (ctx.ORDER() != null) {
-                return matchQuery -> matchQuery.orderBy(var, getOrder(ctx.ORDER()));
-            } else {
-                return matchQuery -> matchQuery.orderBy(var);
-            }
+            return matchQuery -> matchQuery.orderBy(var);
         }
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
@@ -570,7 +570,7 @@ class VarImpl implements VarInternal {
 
                     String resourceRepr;
                     if (resource.isUserDefinedName()) {
-                        resourceRepr = " " + resource.getName();
+                        resourceRepr = " " + resource.getPrintableName();
                     } else if (resource.hasNoProperties()) {
                         resourceRepr = "";
                     } else {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchOrderImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchOrderImpl.java
@@ -19,8 +19,6 @@
 package io.mindmaps.graql.internal.query.match;
 
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.util.Schema;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
@@ -28,19 +26,15 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.mindmaps.util.Schema.ConceptProperty.ITEM_IDENTIFIER;
-import static io.mindmaps.util.Schema.EdgeLabel.SHORTCUT;
-import static io.mindmaps.util.Schema.EdgeProperty.TO_TYPE;
+import static io.mindmaps.util.Schema.ConceptProperty.*;
 
 class MatchOrderImpl implements MatchOrder {
 
     private final String var;
-    private final Optional<String> resourceType;
     private final boolean asc;
 
-    MatchOrderImpl(String var, Optional<String> resourceType, boolean asc) {
+    MatchOrderImpl(String var, boolean asc) {
         this.var = var;
-        this.resourceType = resourceType;
         this.asc = asc;
     }
 
@@ -51,41 +45,27 @@ class MatchOrderImpl implements MatchOrder {
 
     @Override
     public void orderTraversal(MindmapsGraph graph, GraphTraversal<Vertex, Map<String, Vertex>> traversal) {
-        if (resourceType.isPresent()) {
-            // Order by resource type
+        Comparator<Optional<Comparable>> comparator = new ResourceComparator();
+        if (!asc) comparator = comparator.reversed();
 
-            // Look up datatype of resource type
-            String typeId = resourceType.get();
-            Schema.ConceptProperty valueProp = graph.getResourceType(typeId).getDataType().getConceptProperty();
-
-            Comparator<Optional<Comparable>> comparator = new ResourceComparator();
-            if (!asc) comparator = comparator.reversed();
-
-            traversal.select(var).order().by(v -> getResourceValue(graph, v, typeId, valueProp), comparator);
-        } else {
-            // Order by ITEM_IDENTIFIER by default
-            Order order = asc ? Order.incr : Order.decr;
-            traversal.select(var).order().by(ITEM_IDENTIFIER.name(), order);
-        }
+        // Order by VALUE properties by default
+        traversal.select(var).order().by(v -> getValue(graph, v), comparator);
     }
 
     /**
-     * Get the value of an attached resource, used for ordering by resource
+     * Get the value of a resource
      * @param elem the element in the graph (a gremlin object)
-     * @param resourceTypeId the ID of a resource type
-     * @param value the VALUE property to use on the vertex
-     * @return the value of an attached resource, or nothing if there is no resource of this type
+     * @return the value of the concept, or nothing if there is no value
      */
-    private Optional<Comparable> getResourceValue(MindmapsGraph graph, Object elem, String resourceTypeId, Schema.ConceptProperty value) {
+    private Optional<Comparable> getValue(MindmapsGraph graph, Object elem) {
         return graph.getTinkerTraversal().V(elem)
-                .outE(SHORTCUT.getLabel()).has(TO_TYPE.name(), resourceTypeId).inV().values(value.name())
+                .values(VALUE_BOOLEAN.name(), VALUE_LONG.name(), VALUE_DOUBLE.name(), VALUE_STRING.name())
                 .tryNext().map(o -> (Comparable) o);
     }
 
     @Override
     public String toString() {
-        String resourceString = resourceType.map(r -> "(has " + r + ")").orElse("");
-        return "order by $" + var + resourceString + " ";
+        return "order by $" + var + " ";
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
@@ -170,11 +170,6 @@ interface MatchQueryInternal extends MatchQueryAdmin {
 
     @Override
     default MatchQuery orderBy(String varName, boolean asc) {
-        return new MatchQueryOrder(this, new MatchOrderImpl(varName, Optional.empty(), asc));
-    }
-
-    @Override
-    default MatchQuery orderBy(String varName, String resourceType, boolean asc) {
-        return new MatchQueryOrder(this, new MatchOrderImpl(varName, Optional.of(resourceType), asc));
+        return new MatchQueryOrder(this, new MatchOrderImpl(varName, asc));
     }
 }

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryParserTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryParserTest.java
@@ -184,8 +184,8 @@ public class QueryParserTest {
 
     @Test
     public void testOrderQuery() {
-        MatchQuery expected = qb.match(var("x").isa("movie")).orderBy("x", "release-date", false);
-        MatchQuery parsed = qb.parseMatch("match $x isa movie order by $x(has release-date) desc");
+        MatchQuery expected = qb.match(var("x").isa("movie").has("release-date", var("r"))).orderBy("r", false);
+        MatchQuery parsed = qb.parseMatch("match $x isa movie, has release-date $r order by $r desc");
         assertOrderedQueriesEqual(expected, parsed);
     }
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryToStringTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/parser/QueryToStringTest.java
@@ -56,8 +56,9 @@ public class QueryToStringTest {
                 or(
                         var("y").isa("person"),
                         var("y").isa("genre").value(neq("crime"))
-                )
-        ).select("x", "y").orderBy("y").limit(8).offset(4);
+                ),
+                var("y").has("name", var("n"))
+        ).select("x", "y").orderBy("n").limit(8).offset(4);
         assertValidToString(query);
     }
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryModifierTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryModifierTest.java
@@ -20,33 +20,21 @@ package io.mindmaps.graql.query;
 
 import com.google.common.collect.Lists;
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.graph.internal.AbstractMindmapsGraph;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.example.MovieGraphFactory;
 import io.mindmaps.factory.MindmapsTestGraphFactory;
 import io.mindmaps.graql.MatchQuery;
 import io.mindmaps.graql.QueryBuilder;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.mindmaps.util.Schema.ConceptProperty.ITEM_IDENTIFIER;
-import static io.mindmaps.graql.Graql.neq;
-import static io.mindmaps.graql.Graql.or;
-import static io.mindmaps.graql.Graql.var;
-import static io.mindmaps.graql.Graql.withGraph;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static io.mindmaps.graql.Graql.*;
+import static org.junit.Assert.*;
 
 public class MatchQueryModifierTest {
 
@@ -66,31 +54,31 @@ public class MatchQueryModifierTest {
 
     @Test
     public void testOffsetQuery() {
-        MatchQuery query = qb.match(var("x").isa("movie")).orderBy("x", false).offset(4);
+        MatchQuery query = qb.match(var("x").isa("movie").has("name", var("n"))).orderBy("n", false).offset(4);
 
-        assertResultsOrderedById(query, "x", false);
+        assertResultsOrderedByValue(query, "n", false);
     }
 
     @Test
     public void testLimitQuery() {
-        MatchQuery query = qb.match(var("x").isa("movie")).orderBy("x", true).offset(1).limit(3);
+        MatchQuery query = qb.match(var("x").isa("movie").has("title", var("t"))).orderBy("t", true).offset(1).limit(3);
 
-        assertResultsOrderedById(query, "x", true);
+        assertResultsOrderedByValue(query, "t", true);
         assertEquals(3, query.stream().count());
     }
 
     @Test
     public void testOrPatternOrderByResource() {
         MatchQuery query = qb.match(
-                var("x").isa("movie"),
+                var("x").isa("movie").has("tmdb-vote-count", var("v")),
                 var().rel("x").rel("y"),
                 or(
                         var("y").isa("person").id("Marlon-Brando"),
                         var("y").isa("genre").has("name", "crime")
                 )
-        ).orderBy("x", "tmdb-vote-count", false).select("x");
+        ).orderBy("v", false);
 
-        assertOrderedResultsMatch(query, "x", "movie", "Godfather", "Godfather", "Apocalypse-Now", "Heat");
+        assertOrderedResultsMatch(query, "x", "movie", "Godfather", "Godfather", "Apocalypse-Now");
     }
 
     @Test
@@ -101,8 +89,9 @@ public class MatchQueryModifierTest {
                 or(
                         var("y").isa("person"),
                         var("y").isa("genre").value(neq("crime"))
-                )
-        ).orderBy("y").offset(4).limit(8).select("x");
+                ),
+                var("y").has("name", var("n"))
+        ).orderBy("n").offset(4).limit(8).select("x");
 
         QueryUtil.assertResultsMatch(
                 query, "x", "movie", "Hocus-Pocus", "Spy", "The-Muppets", "Godfather", "Apocalypse-Now"
@@ -110,10 +99,10 @@ public class MatchQueryModifierTest {
     }
 
     @Test
-    public void testDegreeOrderedQuery() {
-        MatchQuery query = qb.match(var("the-movie").isa("movie")).orderBy("the-movie", false);
+    public void testValueOrderedQuery() {
+        MatchQuery query = qb.match(var("the-movie").isa("movie").has("title", var("n"))).orderBy("n", false);
 
-        assertResultsOrderedById(query, "the-movie", false);
+        assertResultsOrderedByValue(query, "n", false);
 
         // Make sure all results are included
         QueryUtil.assertResultsMatch(query, "the-movie", "movie", QueryUtil.movies);
@@ -121,25 +110,22 @@ public class MatchQueryModifierTest {
 
     @Test
     public void testVoteCountOrderedQuery() {
-        MatchQuery query = qb.match(var("z").isa("movie")).orderBy("z", "tmdb-vote-count", false);
+        MatchQuery query = qb.match(var("z").isa("movie").has("tmdb-vote-count", var("v"))).orderBy("v", false);
 
         // Make sure movies are in the correct order
         assertOrderedResultsMatch(query, "z", "movie", "Godfather", "Hocus-Pocus", "Apocalypse-Now", "The-Muppets");
-
-        // Movies without a tmdb-vote-count will still be at the end of the results
-        QueryUtil.assertResultsMatch(query, "z", "movie", QueryUtil.movies);
     }
 
     @Test
     public void testOrPatternDistinct() {
         MatchQuery query = qb.match(
-                var("x").isa("movie"),
+                var("x").isa("movie").has("title", var("t")),
                 var().rel("x").rel("y"),
                 or(
                         var("y").isa("genre").has("name", "crime"),
                         var("y").isa("person").id("Marlon-Brando")
                 )
-        ).select("x").orderBy("x", false).distinct();
+        ).select("x").orderBy("t", false).distinct();
 
         assertOrderedResultsMatch(query, "x", "movie", "Heat", "Godfather", "Apocalypse-Now");
     }
@@ -174,7 +160,6 @@ public class MatchQueryModifierTest {
         Queue<String> expectedQueue = new LinkedList<>(Arrays.asList(expectedIds));
 
         query.forEach(results -> {
-            assertEquals(1, results.size());
             Concept result = results.get(var);
             assertNotNull(result);
 
@@ -186,12 +171,9 @@ public class MatchQueryModifierTest {
         assertTrue("expected ids not found: " + expectedQueue, expectedQueue.isEmpty());
     }
 
-    private void assertResultsOrderedById(MatchQuery query, String var, boolean asc) {
-        GraphTraversalSource g = ((AbstractMindmapsGraph) mindmapsGraph).getTinkerTraversal();
-        Stream<String> ids = query.stream().map(results -> results.get(var)).map(
-                result -> (String) g.V().has("ITEM_IDENTIFIER", result.getId()).values(ITEM_IDENTIFIER.name()).next()
-        );
-        assertResultsOrdered(ids, asc);
+    private void assertResultsOrderedByValue(MatchQuery query, String var, boolean asc) {
+        Stream values = query.stream().map(result -> result.get(var).asResource().getValue());
+        assertResultsOrdered(values, asc);
     }
 
     private <T extends Comparable<T>> void assertResultsOrdered(Stream<T> results, boolean asc) {

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/query/MatchQueryTest.java
@@ -38,24 +38,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static io.mindmaps.graql.Graql.all;
-import static io.mindmaps.graql.Graql.and;
-import static io.mindmaps.graql.Graql.any;
-import static io.mindmaps.graql.Graql.contains;
-import static io.mindmaps.graql.Graql.eq;
-import static io.mindmaps.graql.Graql.gt;
-import static io.mindmaps.graql.Graql.gte;
-import static io.mindmaps.graql.Graql.id;
-import static io.mindmaps.graql.Graql.lt;
-import static io.mindmaps.graql.Graql.lte;
-import static io.mindmaps.graql.Graql.neq;
-import static io.mindmaps.graql.Graql.or;
-import static io.mindmaps.graql.Graql.regex;
-import static io.mindmaps.graql.Graql.var;
-import static io.mindmaps.graql.Graql.withGraph;
-import static io.mindmaps.util.Schema.MetaType.ENTITY_TYPE;
-import static io.mindmaps.util.Schema.MetaType.RESOURCE_TYPE;
-import static io.mindmaps.util.Schema.MetaType.RULE_TYPE;
+import static io.mindmaps.graql.Graql.*;
+import static io.mindmaps.util.Schema.MetaType.*;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -362,7 +346,7 @@ public class MatchQueryTest {
     @Test
     public void testRobertDeNiroNotRelatedToSelf() {
         MatchQuery query = qb.match(
-                var().rel("x").rel("y"),
+                var().rel("x").rel("y").isa("has-cast"),
                 var("y").id("Robert-de-Niro")
         ).select("x");
 
@@ -372,7 +356,7 @@ public class MatchQueryTest {
     @Test
     public void testKermitIsRelatedToSelf() {
         MatchQuery query = qb.match(
-                var().rel("x").rel("y"),
+                var().rel("x").rel("y").isa("has-cast"),
                 var("y").id("Kermit-The-Frog")
         ).select("x");
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/query/QueryUtil.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/query/QueryUtil.java
@@ -39,7 +39,6 @@ class QueryUtil {
         Set<String> unfoundSet = Sets.newHashSet(expectedIds);
 
         query.forEach(results -> {
-            assertEquals(1, results.size());
             Concept result = results.get(var);
             assertNotNull(result);
             String id = result.getId();


### PR DESCRIPTION
- Ordering now uses "value"
- Removed special syntax for ordering by an attached resource