### PR TITLE
Removed isa edge logic

### DIFF
--- a/mindmaps-dashboard/src/components/visualiser.vue
+++ b/mindmaps-dashboard/src/components/visualiser.vue
@@ -177,8 +177,6 @@ export default {
 
         shellResponse(resp, err) {
             if(resp != null) {
-                console.log('response is:');
-                console.log(resp);
                 this.graqlResponse = Prism.highlight(resp, PLang.graql);
             }
             else {

--- a/mindmaps-dashboard/src/js/HAL/APITerms.js
+++ b/mindmaps-dashboard/src/js/HAL/APITerms.js
@@ -31,5 +31,3 @@ export const KEY_ID = "_id";
 export const KEY_EMBEDDED = "_embedded";
 export const KEY_TYPE = "_type";
 export const KEY_BASE_TYPE = "_baseType";
-
-export const EDGE_LABEL_ISA = "isa";

--- a/mindmaps-dashboard/src/js/HAL/APIUtils.js
+++ b/mindmaps-dashboard/src/js/HAL/APIUtils.js
@@ -37,28 +37,8 @@ export function leftSignificant(l, r) {
     if(idR === typeL || idR  === baseTypeL)
         return true;
 
-    else if(idL === typeR || idL === baseTypeR)
-        return false;
-
     else
-        return (weight(baseTypeL) > weight(baseTypeR));
-}
-
-/**
- * Given a relationship between two hal resources and the default role name @roleName, what label should the relationship
- * be assigned?
- */
-export function relationshipLabel(a, b, roleName) {
-    var typeA = a[API.KEY_TYPE];
-    var typeB = b[API.KEY_TYPE];
-
-    var idA = a[API.KEY_ID];
-    var idB = b[API.KEY_ID];
-
-    if(idA === typeB || idB === typeA)
-        return API.EDGE_LABEL_ISA;
-
-    return roleName;
+        return false;
 }
 
 /**
@@ -76,24 +56,6 @@ export function resourceProperties(resource) {
 /*
  Internal functions
  */
-
-/**
- * Calculate weight of a hal resource based on its type; used to establish directionality of a relationship between resources.
- */
-function weight(baseType) {
-    var weightMap = {
-        "entity-type": 1,
-        "relation-type": 2,
-        "role-type": 3,
-        "type": 4
-    };
-
-    if (baseType in weightMap)
-        return weightMap[baseType];
-    else
-        return 0;
-}
-
 function buildLabel(resource) {
     var label = resource[API.KEY_ID];
 

--- a/mindmaps-dashboard/src/js/HAL/HALParser.js
+++ b/mindmaps-dashboard/src/js/HAL/HALParser.js
@@ -73,16 +73,15 @@ export default class HALParser {
     parseEmbedded(objs, parent, roleName) {
         _.map(objs, obj => {
             // Add resource and iterate its _embedded field
-            var label = APIUtils.relationshipLabel(obj, parent, roleName);
             var hrefA = this.getHref(obj);
             var hrefB = this.getHref(parent);
 
             this.newResource(hrefA, APIUtils.resourceProperties(obj));
 
             if(APIUtils.leftSignificant(obj, parent))
-                this.newRelationship(hrefA, hrefB, label);
+                this.newRelationship(hrefA, hrefB, roleName);
             else
-                this.newRelationship(hrefB, hrefA, label);
+                this.newRelationship(hrefB, hrefA, roleName);
 
             this.parseHalObject(obj);
 


### PR DESCRIPTION
`isa` edges are now determined in Engine, so we can just use labels from
_embedded as is.
Removed redundant internal `weight()` function as it was never called.