### PR TITLE
Restart animation and physics when adding new nodes

### DIFF
--- a/mindmaps-dashboard/src/components/status.vue
+++ b/mindmaps-dashboard/src/components/status.vue
@@ -40,7 +40,7 @@ along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
                                 <tr><td>Graph Computer config</td><td>{{response['graphdatabase.computer']}}</td></tr>
                                 <tr><td>Engine assets directory</td><td>{{response['server.static-file-dir']}}</td></tr>
                                 <tr><td>Log File</td><td>{{response['logging.file']}}</td></tr>
-                                <tr><td>Logging Level</td><td>{{response['logging.level.']}}</td></tr>
+                                <tr><td>Logging Level</td><td>{{response['logging.level']}}</td></tr>
                                 <tr><td>Background Tasks time lapse</td><td>{{response['backgroundTasks.time-lapse']}}</td></tr>
                                 <tr><td>Background Tasks post processing delay</td><td>{{response['backgroundTasks.post-processing-delay']}}</td></tr>
                                 <tr><td>Batch size</td><td>{{response['blockingLoader.batch-size']}}</td></tr>

--- a/mindmaps-dashboard/src/components/visualiser.vue
+++ b/mindmaps-dashboard/src/components/visualiser.vue
@@ -227,6 +227,9 @@ export default {
             if(this.graqlQuery == undefined)
                 return;
 
+            // Enable graph animation
+            visualiser.setSimulation(true);
+
             engineClient.graqlHAL(this.graqlQuery, this.graphResponse);
             engineClient.graqlShell(this.graqlQuery, this.shellResponse);
             this.resetMsg();
@@ -249,6 +252,9 @@ export default {
             const eventKeys = param.event.srcEvent;
             if(!eventKeys.shiftKey)
                 visualiser.clearGraph();
+
+            // Enable graph animation
+            visualiser.setSimulation(true);
 
             _.map(param.nodes, x => { engineClient.request({url: x, callback: this.typeQueryResponse}) });
         },

--- a/mindmaps-dashboard/src/js/visualiser/Visualiser.js
+++ b/mindmaps-dashboard/src/js/visualiser/Visualiser.js
@@ -114,7 +114,7 @@ export default class Visualiser {
         this.network.on('doubleClick', this.callbacks.doubleClick);
         this.network.on('oncontext', this.callbacks.rightClick);
         this.network.on('hoverNode', this.callbacks.hover);
-        this.network.on('stabilized', () => { this.stopSimulation() });
+        this.network.on('stabilized', () => { this.setSimulation(false) });
 
         return this;
     }
@@ -171,6 +171,17 @@ export default class Visualiser {
         this.edges.clear();
     }
 
+    /**
+     * Stop/start physics simulation and all animation in displayed graph.
+     */
+    setSimulation(state) {
+        if(state)
+            this.network.startSimulation();
+        else
+            this.network.stopSimulation();
+        return this;
+    }
+
     /*
     Internal methods
     */
@@ -206,14 +217,5 @@ export default class Visualiser {
      */
     deleteEdges(nid) {
         this.edges.map(x => { if(x.to === nid || x.from === nid) this.edges.remove(x.id) });
-    }
-
-    /**
-     * Stop physics simulation and all animation in displayed graph.
-     */
-    stopSimulation() {
-        this.network.fit({animation: false});
-        this.network.setOptions({physics: false});
-        return this;
     }
 }


### PR DESCRIPTION
Animation and physics simmulation restart on adding nodes to graph from
subsequent graql queries or clicking.
Fixed status page log level bug.