### PR TITLE
Refactor VarImpl to replace fields with `VarProperty` objects

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/Graql.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/Graql.java
@@ -25,7 +25,7 @@ import io.mindmaps.concept.Concept;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.Disjunction;
 import io.mindmaps.graql.admin.PatternAdmin;
-import io.mindmaps.graql.internal.query.Patterns;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.graql.internal.query.aggregate.Aggregates;
 import io.mindmaps.graql.internal.query.predicate.Predicates;
 import io.mindmaps.graql.internal.util.AdminConverter;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilder.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.parser.QueryParser;
-import io.mindmaps.graql.internal.query.Patterns;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.graql.internal.query.Queries;
 import io.mindmaps.graql.internal.util.AdminConverter;
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
@@ -21,7 +21,7 @@ package io.mindmaps.graql.internal.gremlin;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.VarAdmin;
-import io.mindmaps.graql.internal.query.VarInternal;
+import io.mindmaps.graql.internal.pattern.VarInternal;
 import io.mindmaps.util.ErrorMessage;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/DisjunctionImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/DisjunctionImpl.java
@@ -14,27 +14,25 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
- *
  */
 
-package io.mindmaps.graql.internal.query;
+package io.mindmaps.graql.internal.pattern;
 
-import com.google.common.collect.Sets;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.Disjunction;
 import io.mindmaps.graql.admin.PatternAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
 
-import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toSet;
 
-class ConjunctionImpl<T extends PatternAdmin> implements Conjunction<T> {
+class DisjunctionImpl<T extends PatternAdmin> implements Disjunction<T> {
 
     private final Set<T> patterns;
 
-    ConjunctionImpl(Set<T> patterns) {
+    DisjunctionImpl(Set<T> patterns) {
         this.patterns = patterns;
     }
 
@@ -45,42 +43,27 @@ class ConjunctionImpl<T extends PatternAdmin> implements Conjunction<T> {
 
     @Override
     public Disjunction<Conjunction<VarAdmin>> getDisjunctiveNormalForm() {
-        // Get all disjunctions in query
-        List<Set<Conjunction<VarAdmin>>> disjunctionsOfConjunctions = patterns.stream()
-                .map(p -> p.getDisjunctiveNormalForm().getPatterns())
-                .collect(toList());
-
-        // Get the cartesian product.
-        // in other words, this puts the 'ands' on the inside and the 'ors' on the outside
-        // e.g. (A or B) and (C or D)  <=>  (A and C) or (A and D) or (B and C) or (B and D)
-        Set<Conjunction<VarAdmin>> dnf = Sets.cartesianProduct(disjunctionsOfConjunctions).stream()
-                .map(ConjunctionImpl::fromConjunctions)
+        // Concatenate all disjunctions into one big disjunction
+        Set<Conjunction<VarAdmin>> dnf = patterns.stream()
+                .flatMap(p -> p.getDisjunctiveNormalForm().getPatterns().stream())
                 .collect(toSet());
 
         return Patterns.disjunction(dnf);
-
-        // Wasn't that a horrible function? Here it is in Haskell:
-        //     dnf = map fromConjunctions . sequence . map getDisjunctiveNormalForm . patterns
     }
 
     @Override
-    public boolean isConjunction() {
+    public boolean isDisjunction() {
         return true;
     }
 
     @Override
-    public Conjunction<?> asConjunction() {
+    public Disjunction<?> asDisjunction() {
         return this;
-    }
-
-    private static <U extends PatternAdmin> Conjunction<U> fromConjunctions(List<Conjunction<U>> conjunctions) {
-        Set<U> patterns = conjunctions.stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
-        return Patterns.conjunction(patterns);
     }
 
     @Override
     public boolean equals(Object obj) {
-        return (obj instanceof ConjunctionImpl) && patterns.equals(((ConjunctionImpl) obj).patterns);
+        return (obj instanceof DisjunctionImpl) && patterns.equals(((DisjunctionImpl) obj).patterns);
     }
 
     @Override
@@ -90,7 +73,7 @@ class ConjunctionImpl<T extends PatternAdmin> implements Conjunction<T> {
 
     @Override
     public String toString() {
-        return "{" + patterns.stream().map(s -> s + ";").collect(joining(" ")) + "}";
+        return patterns.stream().map(Object::toString).collect(Collectors.joining(" or "));
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/Patterns.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/Patterns.java
@@ -16,7 +16,7 @@
  * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package io.mindmaps.graql.internal.query;
+package io.mindmaps.graql.internal.pattern;
 
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.Disjunction;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -279,7 +279,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public Var isAbstract() {
-        properties.add(new AbstractProperty());
+        properties.add(new IsAbstractProperty());
         return this;
     }
 
@@ -336,7 +336,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public boolean getAbstract() {
-        return getProperties(AbstractProperty.class).findAny().isPresent();
+        return getProperties(IsAbstractProperty.class).findAny().isPresent();
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -52,8 +52,6 @@ class VarImpl implements VarInternal {
 
     private Optional<String> regex = Optional.empty();
 
-    private boolean valueFlag = false;
-
     private Optional<String> lhs = Optional.empty();
     private Optional<String> rhs = Optional.empty();
 
@@ -96,14 +94,12 @@ class VarImpl implements VarInternal {
         this.name = first.getName();
         this.userDefinedName = first.isUserDefinedName();
 
-        valueFlag = false;
-
         for (VarAdmin var : vars) {
             if (var.isUserDefinedName()) {
                 this.name = var.getName();
             }
 
-            valueFlag |= var.hasValue();
+            if (var.hasValue()) value();
             if (var.getAbstract()) isAbstract();
 
             var.getDatatype().ifPresent(this::datatype);
@@ -141,7 +137,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public Var value() {
-        valueFlag = true;
+        properties.add(new ValueFlagProperty());
         return this;
     }
 
@@ -357,7 +353,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public boolean hasValue() {
-        return valueFlag;
+        return getProperties(ValueFlagProperty.class).findAny().isPresent();
     }
 
     @Override
@@ -405,7 +401,7 @@ class VarImpl implements VarInternal {
     @Override
     public boolean hasNoProperties() {
         // return true if this variable has any properties set
-        return properties.isEmpty() && !valueFlag && !isa.isPresent() && !ako.isPresent() &&
+        return properties.isEmpty() && !isa.isPresent() && !ako.isPresent() &&
                 hasRole.isEmpty() && playsRole.isEmpty() && hasScope.isEmpty() && resources.isEmpty() &&
                 castings.isEmpty();
     }
@@ -413,7 +409,7 @@ class VarImpl implements VarInternal {
     @Override
     public Optional<String> getIdOnly() {
 
-        if (getId().isPresent() && properties.size() == 1 && !valueFlag && !isa.isPresent() && !ako.isPresent() &&
+        if (getId().isPresent() && properties.size() == 1 && !isa.isPresent() && !ako.isPresent() &&
                 hasRole.isEmpty() && playsRole.isEmpty() && hasScope.isEmpty() && resources.isEmpty() &&
                 castings.isEmpty() && !userDefinedName) {
             return getId();

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -50,9 +50,6 @@ class VarImpl implements VarInternal {
     private String name;
     private final boolean userDefinedName;
 
-    private Optional<String> lhs = Optional.empty();
-    private Optional<String> rhs = Optional.empty();
-
     private Optional<VarAdmin> isa = Optional.empty();
     private Optional<VarAdmin> ako = Optional.empty();
 
@@ -297,13 +294,13 @@ class VarImpl implements VarInternal {
 
     @Override
     public Var lhs(String lhs) {
-        this.lhs = Optional.of(lhs);
+        properties.add(new LhsProperty(lhs));
         return this;
     }
 
     @Override
     public Var rhs(String rhs) {
-        this.rhs = Optional.of(rhs);
+        properties.add(new RhsProperty(rhs));
         return this;
     }
 
@@ -451,12 +448,12 @@ class VarImpl implements VarInternal {
 
     @Override
     public Optional<String> getLhs() {
-        return lhs;
+        return getProperties(LhsProperty.class).findAny().map(LhsProperty::getLhs);
     }
 
     @Override
     public Optional<String> getRhs() {
-        return rhs;
+        return getProperties(RhsProperty.class).findAny().map(RhsProperty::getRhs);
     }
 
     @Override
@@ -566,9 +563,6 @@ class VarImpl implements VarInternal {
                     propertiesStrings.add("has " + type + resourceRepr);
                 }
         );
-
-        lhs.ifPresent(s -> propertiesStrings.add("lhs {" + s + "}"));
-        rhs.ifPresent(s -> propertiesStrings.add("rhs {" + s + "}"));
 
         String name = isUserDefinedName() ? getPrintableName() + " " : "";
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -50,8 +50,6 @@ class VarImpl implements VarInternal {
     private String name;
     private final boolean userDefinedName;
 
-    private Optional<String> regex = Optional.empty();
-
     private Optional<String> lhs = Optional.empty();
     private Optional<String> rhs = Optional.empty();
 
@@ -293,7 +291,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public Var regex(String regex) {
-        this.regex = Optional.of(regex);
+        properties.add(new RegexProperty(regex));
         return this;
     }
 
@@ -348,7 +346,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public Optional<String> getRegex() {
-        return regex;
+        return getProperties(RegexProperty.class).findAny().map(RegexProperty::getRegex);
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -16,7 +16,7 @@
  * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package io.mindmaps.graql.internal.query;
+package io.mindmaps.graql.internal.pattern;
 
 import com.google.common.collect.Maps;
 import io.mindmaps.concept.ResourceType;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -28,6 +28,7 @@ import io.mindmaps.graql.admin.ValuePredicateAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.gremlin.MultiTraversal;
 import io.mindmaps.graql.internal.gremlin.VarTraversals;
+import io.mindmaps.graql.internal.pattern.property.AbstractProperty;
 import io.mindmaps.graql.internal.pattern.property.IdProperty;
 import io.mindmaps.graql.internal.pattern.property.ValueProperty;
 import io.mindmaps.graql.internal.pattern.property.VarProperty;
@@ -52,7 +53,6 @@ class VarImpl implements VarInternal {
     private String name;
     private final boolean userDefinedName;
 
-    private boolean abstractFlag = false;
     private Optional<ResourceType.DataType<?>> datatype = Optional.empty();
     private Optional<String> regex = Optional.empty();
 
@@ -108,7 +108,7 @@ class VarImpl implements VarInternal {
             }
 
             valueFlag |= var.hasValue();
-            abstractFlag |= var.getAbstract();
+            if (var.getAbstract()) isAbstract();
 
             var.getDatatype().ifPresent(this::datatype);
             var.getRegex().ifPresent(this::regex);
@@ -289,7 +289,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public Var isAbstract() {
-        abstractFlag = true;
+        properties.add(new AbstractProperty());
         return this;
     }
 
@@ -346,7 +346,7 @@ class VarImpl implements VarInternal {
 
     @Override
     public boolean getAbstract() {
-        return abstractFlag;
+        return getProperties(AbstractProperty.class).findAny().isPresent();
     }
 
     @Override
@@ -560,8 +560,6 @@ class VarImpl implements VarInternal {
         hasResourceTypes.forEach(v -> propertiesStrings.add("has-resource " + v.getPrintableName()));
 
         getDatatypeName().ifPresent(d -> propertiesStrings.add("datatype " + d));
-
-        if (getAbstract()) propertiesStrings.add("is-abstract");
 
         resources.forEach(
                 resource -> {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -509,8 +509,6 @@ class VarImpl implements VarInternal {
 
     @Override
     public String toString() {
-        Set<String> propertiesStrings = new HashSet<>();
-
         Set<VarAdmin> innerVars = getInnerVars();
         innerVars.remove(this);
         innerVars.removeAll(getResources());
@@ -519,11 +517,23 @@ class VarImpl implements VarInternal {
             throw new UnsupportedOperationException("Graql strings cannot represent a query with inner variables");
         }
 
-        properties.forEach(property -> propertiesStrings.add(property.toString()));
+        StringBuilder builder = new StringBuilder();
 
         String name = isUserDefinedName() ? getPrintableName() + " " : "";
 
-        return name + propertiesStrings.stream().collect(joining(", "));
+        builder.append(name);
+
+        boolean first = true;
+
+        for (VarProperty property : properties) {
+            if (!first) {
+                builder.append(" ");
+            }
+            first = false;
+            property.buildString(builder);
+        }
+
+        return builder.toString();
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarInternal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarInternal.java
@@ -16,7 +16,7 @@
  * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package io.mindmaps.graql.internal.query;
+package io.mindmaps.graql.internal.pattern;
 
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.gremlin.MultiTraversal;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarInternal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarInternal.java
@@ -20,8 +20,10 @@ package io.mindmaps.graql.internal.pattern;
 
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.gremlin.MultiTraversal;
+import io.mindmaps.graql.internal.pattern.property.VarProperty;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Internal interface for Var
@@ -32,4 +34,6 @@ public interface VarInternal extends VarAdmin {
      * @return the gremlin traversals that describe this variable
      */
     Set<MultiTraversal> getMultiTraversals();
+
+    <T extends VarProperty> Stream<T> getProperties(Class<T> type);
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractNamedProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractNamedProperty.java
@@ -25,7 +25,7 @@ abstract class AbstractNamedProperty implements VarProperty {
     protected abstract String getProperty();
 
     @Override
-    public String toString() {
-        return getName() + " " + getProperty();
+    public final void buildString(StringBuilder builder) {
+        builder.append(getName()).append(" ").append(getProperty());
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractNamedProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractNamedProperty.java
@@ -18,27 +18,14 @@
 
 package io.mindmaps.graql.internal.pattern.property;
 
-import io.mindmaps.graql.internal.util.StringConverter;
+abstract class AbstractNamedProperty implements VarProperty {
 
-public class IdProperty extends AbstractNamedProperty {
+    protected abstract String getName();
 
-    private final String id;
-
-    public IdProperty(String id) {
-        this.id = id;
-    }
-
-    public String getId() {
-        return id;
-    }
+    protected abstract String getProperty();
 
     @Override
-    protected String getName() {
-        return "id";
-    }
-
-    @Override
-    protected String getProperty() {
-        return StringConverter.valueToString(id);
+    public String toString() {
+        return getName() + " " + getProperty();
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AbstractProperty.java
@@ -1,0 +1,27 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+public class AbstractProperty implements VarProperty {
+
+    @Override
+    public String toString() {
+        return "is-abstract";
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AkoProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/AkoProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class AkoProperty extends AbstractNamedProperty {
+
+    private final VarAdmin superType;
+
+    public AkoProperty(VarAdmin superType) {
+        this.superType = superType;
+    }
+
+    public VarAdmin getSuperType() {
+        return superType;
+    }
+
+    @Override
+    protected String getName() {
+        return "ako";
+    }
+
+    @Override
+    protected String getProperty() {
+        return superType.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/DataTypeProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/DataTypeProperty.java
@@ -1,0 +1,53 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.concept.ResourceType;
+
+public class DataTypeProperty implements VarProperty {
+
+    private final ResourceType.DataType<?> datatype;
+
+    public DataTypeProperty(ResourceType.DataType<?> datatype) {
+        this.datatype = datatype;
+    }
+
+    public ResourceType.DataType<?> getDatatype() {
+        return datatype;
+    }
+
+    @Override
+    public String toString() {
+        return "datatype " + getName();
+    }
+
+    private String getName() {
+        if (datatype == ResourceType.DataType.BOOLEAN) {
+            return "boolean";
+        } else if (datatype == ResourceType.DataType.DOUBLE) {
+            return "double";
+        } else if (datatype == ResourceType.DataType.LONG) {
+            return "long";
+        } else if (datatype == ResourceType.DataType.STRING) {
+            return "string";
+        } else {
+            throw new RuntimeException("Unknown data type: " + datatype.getName());
+        }
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/DataTypeProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/DataTypeProperty.java
@@ -20,7 +20,7 @@ package io.mindmaps.graql.internal.pattern.property;
 
 import io.mindmaps.concept.ResourceType;
 
-public class DataTypeProperty implements VarProperty {
+public class DataTypeProperty extends AbstractNamedProperty {
 
     private final ResourceType.DataType<?> datatype;
 
@@ -33,11 +33,12 @@ public class DataTypeProperty implements VarProperty {
     }
 
     @Override
-    public String toString() {
-        return "datatype " + getName();
+    protected String getName() {
+        return "datatype";
     }
 
-    private String getName() {
+    @Override
+    protected String getProperty() {
         if (datatype == ResourceType.DataType.BOOLEAN) {
             return "boolean";
         } else if (datatype == ResourceType.DataType.DOUBLE) {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasResourceProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasResourceProperty.java
@@ -1,0 +1,58 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class HasResourceProperty extends AbstractNamedProperty {
+
+    private final String resourceType;
+    private final VarAdmin resource;
+
+    public HasResourceProperty(String resourceType, VarAdmin resource) {
+        this.resourceType = resourceType;
+        this.resource = resource.isa(resourceType).admin();
+    }
+
+    public String getType() {
+        return resourceType;
+    }
+
+    public VarAdmin getResource() {
+        return resource;
+    }
+
+    @Override
+    protected String getName() {
+        return "has";
+    }
+
+    @Override
+    protected String getProperty() {
+        String resourceRepr;
+        if (resource.isUserDefinedName()) {
+            resourceRepr = " " + resource.getPrintableName();
+        } else if (resource.hasNoProperties()) {
+            resourceRepr = "";
+        } else {
+            resourceRepr = " " + resource.getValuePredicates().iterator().next().toString();
+        }
+        return resourceType + resourceRepr;
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasResourceTypeProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasResourceTypeProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class HasResourceTypeProperty extends AbstractNamedProperty {
+
+    private final VarAdmin resourceType;
+
+    public HasResourceTypeProperty(VarAdmin resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public VarAdmin getResourceType() {
+        return resourceType;
+    }
+
+    @Override
+    protected String getName() {
+        return "has-resource";
+    }
+
+    @Override
+    protected String getProperty() {
+        return resourceType.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasRoleProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasRoleProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class HasRoleProperty extends AbstractNamedProperty {
+
+    private final VarAdmin role;
+
+    public HasRoleProperty(VarAdmin role) {
+        this.role = role;
+    }
+
+    public VarAdmin getRole() {
+        return role;
+    }
+
+    @Override
+    protected String getName() {
+        return "has-role";
+    }
+
+    @Override
+    protected String getProperty() {
+        return role.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasScopeProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/HasScopeProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class HasScopeProperty extends AbstractNamedProperty {
+
+    private final VarAdmin scope;
+
+    public HasScopeProperty(VarAdmin scope) {
+        this.scope = scope;
+    }
+
+    public VarAdmin getScope() {
+        return scope;
+    }
+
+    @Override
+    protected String getName() {
+        return "has-scope";
+    }
+
+    @Override
+    protected String getProperty() {
+        return scope.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IdProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IdProperty.java
@@ -1,0 +1,39 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.internal.util.StringConverter;
+
+public class IdProperty implements VarProperty {
+
+    private final String id;
+
+    public IdProperty(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "id " + StringConverter.valueToString(id);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsAbstractProperty.java
@@ -21,7 +21,7 @@ package io.mindmaps.graql.internal.pattern.property;
 public class IsAbstractProperty implements VarProperty {
 
     @Override
-    public String toString() {
-        return "is-abstract";
+    public void buildString(StringBuilder builder) {
+        builder.append("is-abstract");
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsAbstractProperty.java
@@ -18,7 +18,7 @@
 
 package io.mindmaps.graql.internal.pattern.property;
 
-public class AbstractProperty implements VarProperty {
+public class IsAbstractProperty implements VarProperty {
 
     @Override
     public String toString() {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsaProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/IsaProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class IsaProperty extends AbstractNamedProperty {
+
+    private final VarAdmin type;
+
+    public IsaProperty(VarAdmin type) {
+        this.type = type;
+    }
+
+    public VarAdmin getType() {
+        return type;
+    }
+
+    @Override
+    protected String getName() {
+        return "isa";
+    }
+
+    @Override
+    protected String getProperty() {
+        return type.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/LhsProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/LhsProperty.java
@@ -1,0 +1,42 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+public class LhsProperty extends AbstractNamedProperty {
+
+    private final String lhs;
+
+    public LhsProperty(String lhs) {
+        this.lhs = lhs;
+    }
+
+    public String getLhs() {
+        return lhs;
+    }
+
+    @Override
+    protected String getName() {
+        return "lhs";
+    }
+
+    @Override
+    protected String getProperty() {
+        return "{" + lhs + "}";
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/PlaysRoleProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/PlaysRoleProperty.java
@@ -1,0 +1,44 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+public class PlaysRoleProperty extends AbstractNamedProperty {
+
+    private final VarAdmin role;
+
+    public PlaysRoleProperty(VarAdmin role) {
+        this.role = role;
+    }
+
+    public VarAdmin getRole() {
+        return role;
+    }
+
+    @Override
+    protected String getName() {
+        return "plays-role";
+    }
+
+    @Override
+    protected String getProperty() {
+        return role.getPrintableName();
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RegexProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RegexProperty.java
@@ -20,7 +20,7 @@ package io.mindmaps.graql.internal.pattern.property;
 
 import io.mindmaps.graql.internal.util.StringConverter;
 
-public class RegexProperty implements VarProperty {
+public class RegexProperty extends AbstractNamedProperty {
 
     private final String regex;
 
@@ -33,7 +33,12 @@ public class RegexProperty implements VarProperty {
     }
 
     @Override
-    public String toString() {
-        return "regex " + StringConverter.valueToString(regex);
+    protected String getName() {
+        return "regex";
+    }
+
+    @Override
+    protected String getProperty() {
+        return StringConverter.valueToString(regex);
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RegexProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RegexProperty.java
@@ -1,0 +1,39 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.internal.util.StringConverter;
+
+public class RegexProperty implements VarProperty {
+
+    private final String regex;
+
+    public RegexProperty(String regex) {
+        this.regex = regex;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    @Override
+    public String toString() {
+        return "regex " + StringConverter.valueToString(regex);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RelationProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RelationProperty.java
@@ -1,0 +1,45 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.VarAdmin;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
+public class RelationProperty implements VarProperty {
+
+    private final Set<VarAdmin.Casting> castings = new HashSet<>();
+
+    public void addCasting(VarAdmin.Casting casting) {
+        castings.add(casting);
+    }
+
+    public Stream<VarAdmin.Casting> getCastings() {
+        return castings.stream();
+    }
+
+    @Override
+    public String toString() {
+        return "(" + castings.stream().map(Object::toString).collect(joining(", ")) + ")";
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RelationProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RelationProperty.java
@@ -39,7 +39,7 @@ public class RelationProperty implements VarProperty {
     }
 
     @Override
-    public String toString() {
-        return "(" + castings.stream().map(Object::toString).collect(joining(", ")) + ")";
+    public void buildString(StringBuilder builder) {
+        builder.append("(").append(castings.stream().map(Object::toString).collect(joining(", "))).append(")");
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RhsProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/RhsProperty.java
@@ -1,0 +1,42 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+public class RhsProperty extends AbstractNamedProperty {
+
+    private final String rhs;
+
+    public RhsProperty(String rhs) {
+        this.rhs = rhs;
+    }
+
+    public String getRhs() {
+        return rhs;
+    }
+
+    @Override
+    protected String getName() {
+        return "rhs";
+    }
+
+    @Override
+    protected String getProperty() {
+        return "{" + rhs + "}";
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueFlagProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueFlagProperty.java
@@ -21,7 +21,7 @@ package io.mindmaps.graql.internal.pattern.property;
 public class ValueFlagProperty implements VarProperty {
 
     @Override
-    public String toString() {
-        return "value";
+    public void buildString(StringBuilder builder) {
+        builder.append("value");
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueFlagProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueFlagProperty.java
@@ -1,0 +1,27 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+public class ValueFlagProperty implements VarProperty {
+
+    @Override
+    public String toString() {
+        return "value";
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueProperty.java
@@ -20,7 +20,7 @@ package io.mindmaps.graql.internal.pattern.property;
 
 import io.mindmaps.graql.admin.ValuePredicateAdmin;
 
-public class ValueProperty implements VarProperty {
+public class ValueProperty extends AbstractNamedProperty {
 
     private final ValuePredicateAdmin predicate;
 
@@ -33,7 +33,12 @@ public class ValueProperty implements VarProperty {
     }
 
     @Override
-    public String toString() {
-        return "value " + predicate;
+    protected String getName() {
+        return "value";
+    }
+
+    @Override
+    protected String getProperty() {
+        return predicate.toString();
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/ValueProperty.java
@@ -1,0 +1,39 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+import io.mindmaps.graql.admin.ValuePredicateAdmin;
+
+public class ValueProperty implements VarProperty {
+
+    private final ValuePredicateAdmin predicate;
+
+    public ValueProperty(ValuePredicateAdmin predicate) {
+        this.predicate = predicate;
+    }
+
+    public ValuePredicateAdmin getPredicate() {
+        return predicate;
+    }
+
+    @Override
+    public String toString() {
+        return "value " + predicate;
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/VarProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/VarProperty.java
@@ -19,4 +19,6 @@
 package io.mindmaps.graql.internal.pattern.property;
 
 public interface VarProperty {
+
+    void buildString(StringBuilder builder);
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/VarProperty.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/property/VarProperty.java
@@ -1,0 +1,22 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.pattern.property;
+
+public interface VarProperty {
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
@@ -30,6 +30,7 @@ import io.mindmaps.concept.RoleType;
 import io.mindmaps.concept.Type;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.util.GraqlType;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.util.Schema;
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/AtomBase.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/AtomBase.java
@@ -28,7 +28,7 @@ import io.mindmaps.graql.*;
 import io.mindmaps.graql.admin.PatternAdmin;
 import io.mindmaps.graql.admin.ValuePredicateAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
-import io.mindmaps.graql.internal.query.Patterns;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.graql.internal.reasoner.query.Query;
 import javafx.util.Pair;
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/Query.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/Query.java
@@ -30,7 +30,7 @@ import io.mindmaps.graql.internal.query.match.MatchQueryInternal;
 import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.graql.admin.PatternAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
-import io.mindmaps.graql.internal.query.Patterns;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.graql.internal.reasoner.predicate.Atomic;
 import io.mindmaps.graql.internal.reasoner.predicate.AtomicFactory;
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/query/PatternImplTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/query/PatternImplTest.java
@@ -23,7 +23,7 @@ import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.Disjunction;
 import io.mindmaps.graql.admin.PatternAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
-import io.mindmaps.graql.internal.query.*;
+import io.mindmaps.graql.internal.pattern.Patterns;
 import org.junit.Test;
 
 import java.util.HashSet;


### PR DESCRIPTION
- Create several `VarProperty` classes for each kind of Graql property
- Simplify `VarImpl#toString` to delegate to `VarProperty`
- Each property contains the appropriate fields, plus a `buildString` method

This is the first of a series of refactors. Ideally, we will eventually have *all* information respecting a particular property inside the respective `VarProperty` class.

e.g. `HasResourceProperty` will contain:
- A method to create gremlin traversals to find instances with resources
- A method that will insert resources on instances
- A method that will delete resources on instances