### PR TITLE
Functionality #9961 Revert to old physics model

### DIFF
--- a/mindmaps-dashboard/src/js/visualiser/Visualiser.js
+++ b/mindmaps-dashboard/src/js/visualiser/Visualiser.js
@@ -55,11 +55,8 @@ export default class Visualiser {
             },
             physics: {
                 "repulsion": {
-                  "centralGravity": 0.6,
-                  "springLength": 360,
-                  "springConstant": 0.09,
-                  "nodeDistance": 350,
-                  "damping": 0.82
+                  "centralGravity": 0.01,
+                  "damping": 0.5
                 },
                 "minVelocity": 0.75,
                 "solver": "repulsion"


### PR DESCRIPTION
Reverting to forceAtlas2 caused:
    Bug #10099 Graph keeps spinning with previous physics model

This appears to be related to the forceAtlas2 model itself and visjs
doesnt allow effective disabling of physics post stabilisation. As such,
reducing spring length and upping the spring constant on the repulsion
model was chosen instead; since it produces similar results.