### PR TITLE
Make Travis logs more verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 notifications:
   slack: mindmapsdb:3M1bWW0kGQ7LdniMmKeaY3o5
 script:
-    - mvn test jacoco:report coveralls:report -q
+    - mvn test jacoco:report coveralls:report
 before_install:
   - sudo apt-get -y install npm
   - npm install -g npm


### PR DESCRIPTION
This is so we can see information such as how long each test took to run.