### PR TITLE
performance optimisation

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/Utility.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/Utility.java
@@ -27,7 +27,6 @@ import io.mindmaps.graql.Graql;
 import io.mindmaps.graql.Var;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.pattern.Patterns;
-import io.mindmaps.graql.internal.reasoner.query.AtomicQuery;
 import io.mindmaps.graql.MatchQuery;
 import io.mindmaps.graql.internal.reasoner.predicate.Atomic;
 import io.mindmaps.util.ErrorMessage;
@@ -65,17 +64,6 @@ public class Utility {
             }
             System.out.println();
         }
-    }
-
-    public static AtomicQuery findEquivalentAtomicQuery(AtomicQuery query, Set<AtomicQuery> queries) {
-        AtomicQuery equivalentQuery = null;
-        Iterator<AtomicQuery> it = queries.iterator();
-        while( it.hasNext() && equivalentQuery == null) {
-            AtomicQuery current = it.next();
-            if (query.isEquivalent(current))
-                equivalentQuery = current;
-        }
-        return equivalentQuery;
     }
 
     public static Set<RoleType> getCompatibleRoleTypes(String typeId, String relId, MindmapsGraph graph) {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/AtomBase.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/AtomBase.java
@@ -39,9 +39,7 @@ public abstract class AtomBase implements Atomic{
 
     protected String varName;
     protected final String typeId;
-
     protected final PatternAdmin atomPattern;
-
     private Query parent = null;
 
     public AtomBase() {
@@ -251,7 +249,6 @@ public abstract class AtomBase implements Atomic{
     }
 
     @Override
-    //TODO change sub behaviour
     public Map<RoleType, String> getRoleConceptIdMap(){
         Map<RoleType, String> roleConceptMap = new HashMap<>();
         Map<String, Atomic> varSubMap = getVarSubMap();
@@ -278,9 +275,6 @@ public abstract class AtomBase implements Atomic{
         return roleVarTypeMap;
     }
 
-    public Map<RoleType, Pair<String, Type>> getRoleVarTypeMap() {
-        return new HashMap<>();
-    }
-
+    public Map<RoleType, Pair<String, Type>> getRoleVarTypeMap() { return new HashMap<>();}
 }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/Relation.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/predicate/Relation.java
@@ -35,6 +35,7 @@ import static io.mindmaps.graql.internal.reasoner.Utility.getCompatibleRoleTypes
 public class Relation extends AtomBase {
 
     private final Set<VarAdmin.Casting> castings = new HashSet<>();
+    private Map<RoleType, Pair<String, Type>> roleVarTypeMap = null;
 
     public Relation(VarAdmin pattern) {
         super(pattern);
@@ -214,11 +215,9 @@ public class Relation extends AtomBase {
      * Attempts to infer the implicit roleTypes and matching types based on contents of the parent query
      * @return map containing a RoleType-Type pair
      */
-    public Map<RoleType, Pair<String, Type>> getRoleVarTypeMap() {
+    private Map<RoleType, Pair<String, Type>> computeRoleVarTypeMap() {
         Map<RoleType, Pair<String, Type>> roleVarTypeMap = new HashMap<>();
-
         if (getParentQuery() == null) return roleVarTypeMap;
-
 
         MindmapsGraph graph =  getParentQuery().getGraph().orElse(null);
         Map<String, Type> varTypeMap = getParentQuery().getVarTypeMap();
@@ -254,7 +253,6 @@ public class Relation extends AtomBase {
                 }
             }
         }
-
         Collection<RoleType> rolesToAllocate = graph.getRelationType(getTypeId()).hasRoles();
         rolesToAllocate.removeAll(allocatedRoles);
         varsToAllocate.removeAll(allocatedVars);
@@ -264,7 +262,13 @@ public class Relation extends AtomBase {
             Type type = varTypeMap.get(var);
             roleVarTypeMap.put(role, new Pair<>(var, type));
         }
+        return roleVarTypeMap;
+    }
 
+    @Override
+    public Map<RoleType, Pair<String, Type>> getRoleVarTypeMap() {
+        if (roleVarTypeMap == null)
+            roleVarTypeMap = computeRoleVarTypeMap();
         return roleVarTypeMap;
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/AtomicMatchQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/AtomicMatchQuery.java
@@ -7,7 +7,6 @@ import io.mindmaps.graql.internal.reasoner.predicate.Atomic;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static io.mindmaps.graql.internal.reasoner.Utility.findEquivalentAtomicQuery;
 import static io.mindmaps.graql.internal.reasoner.query.QueryAnswers.getUnifiedAnswers;
 
 public class AtomicMatchQuery extends AtomicQuery{
@@ -43,20 +42,16 @@ public class AtomicMatchQuery extends AtomicQuery{
     }
 
     @Override
-    public void memoryLookup(Map<AtomicQuery, QueryAnswers> matAnswers) {
-        QueryAnswers memAnswers = new QueryAnswers();
-
-        if (matAnswers.keySet().contains(this)) {
-            AtomicQuery equivalentQuery = findEquivalentAtomicQuery(this, matAnswers.keySet());
-            memAnswers = getUnifiedAnswers(this, equivalentQuery, matAnswers.get(equivalentQuery));
-        }
-        answers.addAll(memAnswers);
+    public void memoryLookup(Map<AtomicQuery, AtomicQuery> matAnswers) {
+        AtomicQuery equivalentQuery = matAnswers.get(this);
+        if(equivalentQuery != null)
+            answers.addAll(getUnifiedAnswers(this, equivalentQuery, equivalentQuery.getAnswers()));
     }
 
     @Override
-    public void propagateAnswers(Map<AtomicQuery, QueryAnswers> matAnswers) {
+    public void propagateAnswers(Map<AtomicQuery, AtomicQuery> matAnswers) {
         getChildren().forEach(childQuery -> {
-            QueryAnswers ans = getUnifiedAnswers(childQuery, this, matAnswers.get(this));
+            QueryAnswers ans = getUnifiedAnswers(childQuery, this, matAnswers.get(this).getAnswers());
             childQuery.getAnswers().addAll(ans);
             childQuery.propagateAnswers(matAnswers);
         });

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/Query.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/Query.java
@@ -149,10 +149,10 @@ public class Query implements MatchQueryInternal {
 
     public QueryAnswers getAnswers(){ throw new IllegalStateException(ErrorMessage.ANSWER_ERROR.getMessage());}
     public void DBlookup(){ throw new IllegalStateException(ErrorMessage.ANSWER_ERROR.getMessage());}
-    public void memoryLookup(Map<AtomicQuery, QueryAnswers> matAnswers){
+    public void memoryLookup(Map<AtomicQuery, AtomicQuery> matAnswers){
         throw new IllegalStateException(ErrorMessage.ANSWER_ERROR.getMessage());
     }
-    public void propagateAnswers(Map<AtomicQuery, QueryAnswers> matAnswers){
+    public void propagateAnswers(Map<AtomicQuery, AtomicQuery> matAnswers){
         throw new IllegalStateException(ErrorMessage.ANSWER_ERROR.getMessage());
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/ReasonerMatchQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/query/ReasonerMatchQuery.java
@@ -22,11 +22,6 @@ public class ReasonerMatchQuery extends Query{
         answers = new QueryAnswers(ans);
     }
 
-    public ReasonerMatchQuery(Query query, QueryAnswers ans){
-        super(query);
-        answers = new QueryAnswers(ans);
-    }
-
     @Override
     public Stream<Map<String, Concept>> stream() {
         return answers.stream();

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/rule/InferenceRule.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/reasoner/rule/InferenceRule.java
@@ -5,7 +5,6 @@ import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.Type;
 import io.mindmaps.graql.Graql;
 import io.mindmaps.graql.QueryBuilder;
-import io.mindmaps.graql.internal.pattern.Patterns;
 import io.mindmaps.graql.internal.reasoner.predicate.Atomic;
 import io.mindmaps.graql.internal.reasoner.query.AtomicQuery;
 import io.mindmaps.graql.internal.reasoner.query.Query;
@@ -61,7 +60,6 @@ public class InferenceRule {
         Type RHStype = getRuleConclusionType();
         if (rule.getHypothesisTypes().contains(RHStype) )
             ruleRecursive = true;
-
         return ruleRecursive;
     }
 

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/reasoner/ReasonerTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/reasoner/ReasonerTest.java
@@ -218,8 +218,8 @@ public class ReasonerTest {
     //Bug with unification, perhaps should unify select vars not atom vars
     public void testVarContraction3(){
         MindmapsGraph graph = SNBGraph.getGraph();
-        String body = "match $x isa person;";
-        String head = "match ($x, $x) isa knows;";
+        String body = "$x isa person;";
+        String head = "($x, $x) isa knows;";
         graph.putRule("test", body, head, graph.getMetaRuleInference());
 
         String queryString = "match ($x, $y) isa knows;$x id 'Bob';select $y;";

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/reasoner/inference/MoogiInferenceTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/reasoner/inference/MoogiInferenceTest.java
@@ -18,12 +18,12 @@ public class MoogiInferenceTest {
     private static MindmapsGraph graph;
     private static Reasoner reasoner;
     private static QueryBuilder qb;
-    private static String dataDir = "femtomoogi/";
-    private static String schemaFile = dataDir + "schema.gql";
-    private static String entityFile = dataDir + "entities-new.gql";
-    private static String assertionFile = dataDir + "assertions_2-new.gql";
-    private static String assertionFile2 = dataDir + "assertions_3-new.gql";
-    private static String ruleFile = dataDir + "rules.gql";
+    private final static String dataDir = "femtomoogi/";
+    private final static String schemaFile = dataDir + "schema.gql";
+    private final static String entityFile = dataDir + "entities-new.gql";
+    private final static String assertionFile = dataDir + "assertions_2-new.gql";
+    private final static String assertionFile2 = dataDir + "assertions_3-new.gql";
+    private final static String ruleFile = dataDir + "rules.gql";
 
     @BeforeClass
     public static void setUpClass() {


### PR DESCRIPTION
- change a single DB lookup to a memory lookup
- simplified memory lookup
- computing role inferences for relations only once