### PR TITLE
Add support for queries such as "match $x;"

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Sets;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.gremlin.fragment.Fragment;
+import io.mindmaps.graql.internal.gremlin.fragment.Fragments;
 import io.mindmaps.graql.internal.pattern.property.VarPropertyInternal;
 import io.mindmaps.util.ErrorMessage;
 
@@ -175,8 +176,11 @@ class ConjunctionQuery {
 
         if (shortcutTraversal.isValid()) {
             return Stream.of(shortcutTraversal.getEquivalentFragmentSet());
-        } else {
+        } else if (!traversals.isEmpty()) {
             return traversals.stream();
+        } else {
+            // If this variable has no properties, only confirm that it is not a casting and nothing else.
+            return Stream.of(EquivalentFragmentSet.create(Fragments.notCasting(start)));
         }
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/FragmentPriority.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/FragmentPriority.java
@@ -68,6 +68,11 @@ public enum FragmentPriority {
      * Confirming that castings are all distinct
      */
     // TODO: Should this have higher priority?
-    DISTINCT_CASTING;
+    DISTINCT_CASTING,
+
+    /**
+     * The identity step, that does nothing
+     */
+    NOT_CASTING
 
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragments.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragments.java
@@ -113,6 +113,10 @@ public class Fragments {
         return new ValueFlagFragment(start);
     }
 
+    public static NotCastingFragment notCasting(String start) {
+        return new NotCastingFragment(start);
+    }
+
     @SuppressWarnings("unchecked")
     static GraphTraversal<Vertex, Vertex> outSubs(GraphTraversal<Vertex, Vertex> traversal) {
         return traversal.union(__.identity(), __.repeat(__.out(SUB.getLabel())).emit()).unfold();

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/NotCastingFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/NotCastingFragment.java
@@ -1,0 +1,34 @@
+package io.mindmaps.graql.internal.gremlin.fragment;
+
+import io.mindmaps.graql.internal.gremlin.FragmentPriority;
+import io.mindmaps.util.Schema;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+class NotCastingFragment extends AbstractFragment {
+
+    NotCastingFragment(String start) {
+        super(start);
+    }
+
+    @Override
+    public void applyTraversal(GraphTraversal<Vertex, Vertex> traversal) {
+        traversal.not(__.hasLabel(Schema.BaseType.CASTING.name()));
+    }
+
+    @Override
+    public String getName() {
+        return "[not-casting]";
+    }
+
+    @Override
+    public FragmentPriority getPriority() {
+        return FragmentPriority.NOT_CASTING;
+    }
+
+    @Override
+    public long fragmentCost(long previousCost) {
+        return previousCost;
+    }
+}

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
@@ -496,6 +496,25 @@ public class MatchQueryTest extends AbstractMovieGraphTest {
         assertEquals(0, query.stream().count());
     }
 
+    @Test
+    public void testMatchAll() {
+        MatchQuery query = qb.match(var("x"));
+
+        query.get("x").forEach(concept -> {
+            // Make sure results contain both instances and types, but never castings
+            assertFalse(concept.type().isRoleType());
+            assertTrue(concept.isType() || concept.isInstance());
+        });
+    }
+
+    @Test
+    public void testMatchAllPairs() {
+        long numConcepts = qb.match(var("x")).stream().count();
+        MatchQuery pairs = qb.match(var("x"), var("y"));
+
+        assertEquals(numConcepts * numConcepts, pairs.stream().count());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testMatchEmpty() {
         qb.match().execute();

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
@@ -500,10 +500,14 @@ public class MatchQueryTest extends AbstractMovieGraphTest {
     public void testMatchAll() {
         MatchQuery query = qb.match(var("x"));
 
+        // Make sure there a reasonable number of results
+        assertTrue(query.stream().count() > 10);
+
         query.get("x").forEach(concept -> {
-            // Make sure results contain both instances and types, but never castings
-            assertFalse(concept.type().isRoleType());
-            assertTrue(concept.isType() || concept.isInstance());
+            // Make sure results never contain castings
+            if (concept.type() != null) {
+                assertFalse(concept.type().isRoleType());
+            }
         });
     }
 
@@ -511,7 +515,8 @@ public class MatchQueryTest extends AbstractMovieGraphTest {
     public void testMatchAllPairs() {
         long numConcepts = qb.match(var("x")).stream().count();
         MatchQuery pairs = qb.match(var("x"), var("y"));
-
+        
+        // We expect there to be a result for every pair of concepts
         assertEquals(numConcepts * numConcepts, pairs.stream().count());
     }
 


### PR DESCRIPTION
Support queries where no properties are defined, that should return every concept in the graph.