### PR TITLE
Make unique resource types to enable Primary Key Type Behaviour.

### DIFF
--- a/mindmaps-core/src/main/java/io/mindmaps/MindmapsGraph.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/MindmapsGraph.java
@@ -54,13 +54,24 @@ public interface MindmapsGraph extends AutoCloseable{
     /**
      *
      * @param id A unique Id for the Resource Type
-     * @param type The data type of the resource type.
+     * @param dataType The data type of the resource type.
      *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
      * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
      *           This should match the parameter type
      * @return A new or existing Resource Type with the provided Id.
      */
-    <V> ResourceType <V> putResourceType(String id, ResourceType.DataType<V> type);
+    <V> ResourceType <V> putResourceType(String id, ResourceType.DataType<V> dataType);
+
+    /**
+     *
+     * @param id A unique Id for the Resource Type
+     * @param dataType The data type of the resource type.
+     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
+     *           This should match the parameter type
+     * @return A new or existing Resource Type with the provided Id which guarantees that it's instances can only be connected to one entity.
+     */
+    <V> ResourceType <V> putResourceTypeUnique(String id, ResourceType.DataType<V> dataType);
 
     /**
      *

--- a/mindmaps-core/src/main/java/io/mindmaps/concept/ResourceType.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/concept/ResourceType.java
@@ -97,6 +97,12 @@ public interface ResourceType<D> extends Type {
     String getRegex();
 
     /**
+     *
+     * @return True if the resource type is unique and its instances are limited to one connection to an entity
+     */
+    Boolean isUnique();
+
+    /**
      * A class used to hold the supported data types of resources and any other concepts.
      * This is used tp constrain value data types to only those we explicitly support.
      * @param <D> The data type.

--- a/mindmaps-core/src/main/java/io/mindmaps/concept/Rule.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/concept/Rule.java
@@ -58,14 +58,14 @@ public interface Rule extends Instance{
      *
      * @return
      */
-    boolean getExpectation();
+    Boolean getExpectation();
 
     //TODO: Fill out details on this method
     /**
      *
      * @return
      */
-    boolean isMaterialise();
+    Boolean isMaterialise();
 
     /**
      *

--- a/mindmaps-core/src/main/java/io/mindmaps/exception/ConceptNotUniqueException.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/exception/ConceptNotUniqueException.java
@@ -18,19 +18,25 @@
 
 package io.mindmaps.exception;
 
-import io.mindmaps.util.Schema;
-import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.concept.Concept;
+import io.mindmaps.concept.Instance;
+import io.mindmaps.concept.Resource;
+import io.mindmaps.util.ErrorMessage;
+import io.mindmaps.util.Schema;
 
 /**
  * This exception is thrown when two concepts attept to have the same unique id.
  */
-public class ConceptIdNotUniqueException extends ConceptException {
-    public ConceptIdNotUniqueException(Concept concept, Schema.ConceptProperty type, String id) {
+public class ConceptNotUniqueException extends ConceptException {
+    public ConceptNotUniqueException(Concept concept, Schema.ConceptProperty type, String id) {
         super(ErrorMessage.ID_NOT_UNIQUE.getMessage(concept.toString(), type.name(), id));
     }
 
-    public ConceptIdNotUniqueException(Concept concept, String id){
+    public ConceptNotUniqueException(Concept concept, String id){
         super(ErrorMessage.ID_ALREADY_TAKEN.getMessage(id, concept.toString()));
+    }
+
+    public ConceptNotUniqueException(Resource resource, Instance instance){
+        super(ErrorMessage.RESOURCE_TYPE_UNIQUE.getMessage(resource.getId(), instance.getId()));
     }
 }

--- a/mindmaps-core/src/main/java/io/mindmaps/util/ErrorMessage.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/util/ErrorMessage.java
@@ -51,7 +51,8 @@ public enum ErrorMessage {
     CANNOT_LOAD_EXAMPLE("Cannot load example to this graph. Please try a new empty graph."),
     META_TYPE_IMMUTABLE("The meta type [%s] is immutable"),
     UNSUPPORTED_GRAPH("The graph backend of [%s] does not support an [%s] operation."),
-    CANNOT_SUBCLASS_META("The Meta Concept [%s] cannot be a super type of [%s]"),
+    CANNOT_SUBCLASS_META("The Meta Concept [%s] cannot be a super type of [%s]."),
+    RESOURCE_TYPE_UNIQUE("The resource [%s] is unique and is already attached to [%s]."),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/AbstractMindmapsGraph.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/AbstractMindmapsGraph.java
@@ -271,7 +271,17 @@ public abstract class AbstractMindmapsGraph<G extends Graph> implements Mindmaps
         return elementFactory.buildResourceType(
                 putConceptType(id, Schema.BaseType.RESOURCE_TYPE, getMetaResourceType()).getVertex(),
                 getMetaResourceType(),
-                dataType);
+                dataType,
+                false);
+    }
+
+    @Override
+    public <V> ResourceType <V> putResourceTypeUnique(String id, ResourceType.DataType<V> dataType){
+        return elementFactory.buildResourceType(
+                putConceptType(id, Schema.BaseType.RESOURCE_TYPE, getMetaResourceType()).getVertex(),
+                getMetaResourceType(),
+                dataType,
+                true);
     }
 
     @Override

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/AbstractMindmapsGraph.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/AbstractMindmapsGraph.java
@@ -32,7 +32,7 @@ import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.RuleType;
 import io.mindmaps.concept.Type;
 import io.mindmaps.exception.ConceptException;
-import io.mindmaps.exception.ConceptIdNotUniqueException;
+import io.mindmaps.exception.ConceptNotUniqueException;
 import io.mindmaps.exception.GraphRuntimeException;
 import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.exception.MoreThanOneConceptException;
@@ -231,7 +231,7 @@ public abstract class AbstractMindmapsGraph<G extends Graph> implements Mindmaps
             vertex.property(Schema.ConceptProperty.ITEM_IDENTIFIER.name(), itemIdentifier);
         } else {
             if(!baseType.name().equals(concept.getBaseType()))
-                throw new ConceptIdNotUniqueException(concept, itemIdentifier);
+                throw new ConceptNotUniqueException(concept, itemIdentifier);
             vertex = concept.getVertex();
         }
         return vertex;

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
@@ -31,7 +31,7 @@ import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.RuleType;
 import io.mindmaps.concept.Type;
 import io.mindmaps.exception.ConceptException;
-import io.mindmaps.exception.ConceptIdNotUniqueException;
+import io.mindmaps.exception.ConceptNotUniqueException;
 import io.mindmaps.exception.InvalidConceptTypeException;
 import io.mindmaps.exception.InvalidConceptValueException;
 import io.mindmaps.exception.MoreThanOneEdgeException;
@@ -122,7 +122,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
         if(mindmapsGraph.isBatchLoadingEnabled() || updateAllowed(key, id))
             return setProperty(key, id);
         else
-            throw new ConceptIdNotUniqueException(this, key, id);
+            throw new ConceptNotUniqueException(this, key, id);
     }
 
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
@@ -59,7 +59,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
         return (T) this;
     }
 
-    final AbstractMindmapsGraph mindmapsGraph;
+    private final AbstractMindmapsGraph mindmapsGraph;
     private Vertex vertex;
 
     ConceptImpl(Vertex v, V type, AbstractMindmapsGraph mindmapsGraph){
@@ -642,7 +642,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      *
      * @return The mindmaps graph this concept is bound to.
      */
-    AbstractMindmapsGraph getMindmapsGraph() {return mindmapsGraph;}
+    protected AbstractMindmapsGraph getMindmapsGraph() {return mindmapsGraph;}
 
     //--------- Create Links -------//
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
@@ -95,19 +95,6 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
     }
 
     /**
-     *
-     * @param key The key of the property to retrieve
-     * @return The value in the property
-     */
-    private Object getProperty(String key){
-        VertexProperty property = vertex.property(key);
-        if(property != null && property.isPresent())
-            return property.value();
-        else
-            return null;
-    }
-
-    /**
      * Deletes the concept.
      * @throws ConceptException Throws an exception if the node has any edges attached to it.
      */
@@ -557,7 +544,11 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      * @return The value stored in the property
      */
     public Object getProperty(Schema.ConceptProperty key){
-        return getProperty(key.name());
+        VertexProperty property = vertex.property(key.name());
+        if(property != null && property.isPresent())
+            return property.value();
+        else
+            return null;
     }
 
     /**
@@ -609,7 +600,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      * @return The id of the type of this concept. This is a shortcut used to prevent traversals.
      */
     public String getType(){
-        return String.valueOf(getProperty(Schema.ConceptProperty.TYPE));
+        return (String) getProperty(Schema.ConceptProperty.TYPE);
     }
 
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ConceptImpl.java
@@ -543,12 +543,18 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      * @param key The key of the non-unique property to retrieve
      * @return The value stored in the property
      */
-    public Object getProperty(Schema.ConceptProperty key){
+    @SuppressWarnings("unchecked")
+    public <X extends Object> X getProperty(Schema.ConceptProperty key){
         VertexProperty property = vertex.property(key.name());
         if(property != null && property.isPresent())
-            return property.value();
-        else
-            return null;
+            return (X) property.value();
+        return null;
+    }
+    public Boolean getPropertyBoolean(Schema.ConceptProperty key){
+        Boolean value = getProperty(key);
+        if(value == null)
+            return false;
+        return value;
     }
 
     /**
@@ -592,7 +598,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      */
     @Override
     public String getId(){
-        return (String) getProperty(Schema.ConceptProperty.ITEM_IDENTIFIER);
+        return getProperty(Schema.ConceptProperty.ITEM_IDENTIFIER);
     }
 
     /**
@@ -600,7 +606,7 @@ abstract class ConceptImpl<T extends Concept, V extends Type> implements Concept
      * @return The id of the type of this concept. This is a shortcut used to prevent traversals.
      */
     public String getType(){
-        return (String) getProperty(Schema.ConceptProperty.TYPE);
+        return getProperty(Schema.ConceptProperty.TYPE);
     }
 
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ElementFactory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ElementFactory.java
@@ -60,8 +60,8 @@ final class ElementFactory {
     public <V> ResourceTypeImpl<V> buildResourceType(Vertex v, Type type){
         return new ResourceTypeImpl<>(v, type, mindmapsGraph);
     }
-    public <V> ResourceTypeImpl<V> buildResourceType(Vertex v, Type type, ResourceType.DataType<V> dataType){
-        return new ResourceTypeImpl<>(v, type, mindmapsGraph, dataType);
+    public <V> ResourceTypeImpl<V> buildResourceType(Vertex v, Type type, ResourceType.DataType<V> dataType, boolean isUnique){
+        return new ResourceTypeImpl<>(v, type, mindmapsGraph, dataType, isUnique);
     }
 
     public RelationTypeImpl buildRelationType(Vertex v, Type type){

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/InstanceImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/InstanceImpl.java
@@ -71,7 +71,7 @@ abstract class InstanceImpl<T extends Instance, V extends Type> extends ConceptI
      * @return The inner index value of some concepts.
      */
     public String getIndex(){
-        return (String) getProperty(Schema.ConceptProperty.INDEX);
+        return getProperty(Schema.ConceptProperty.INDEX);
     }
 
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationImpl.java
@@ -18,6 +18,8 @@
 
 package io.mindmaps.graph.internal;
 
+import io.mindmaps.concept.Resource;
+import io.mindmaps.exception.ConceptNotUniqueException;
 import io.mindmaps.util.Schema;
 import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.exception.ConceptException;
@@ -129,6 +131,13 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
     public Relation putRolePlayer(RoleType roleType, Instance instance) {
         if(roleType == null){
             throw new IllegalArgumentException(ErrorMessage.ROLE_IS_NULL.getMessage(instance));
+        }
+
+        if(instance != null && instance.isResource()){
+            Resource<Object> resource = instance.asResource();
+            if(resource.type().isUnique() && !resource.ownerInstances().isEmpty()) {
+                throw new ConceptNotUniqueException(resource, resource.ownerInstances().iterator().next());
+            }
         }
 
         if(mindmapsGraph.isBatchLoadingEnabled()) {

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationImpl.java
@@ -140,12 +140,12 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
             }
         }
 
-        if(mindmapsGraph.isBatchLoadingEnabled()) {
+        if(getMindmapsGraph().isBatchLoadingEnabled()) {
             return addNewRolePlayer(null, roleType, instance);
         } else {
             Map<RoleType, Instance> roleMap = rolePlayers();
             roleMap.put(roleType, instance);
-            Relation otherRelation = mindmapsGraph.getRelation(type(), roleMap);
+            Relation otherRelation = getMindmapsGraph().getRelation(type(), roleMap);
 
             if(otherRelation == null){
                 return addNewRolePlayer(roleMap, roleType, instance);
@@ -167,9 +167,9 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
      */
     private Relation addNewRolePlayer(Map<RoleType, Instance> roleMap, RoleType roleType, Instance instance){
         if(instance != null)
-            mindmapsGraph.putCasting((RoleTypeImpl) roleType, (InstanceImpl) instance, this);
+            getMindmapsGraph().putCasting((RoleTypeImpl) roleType, (InstanceImpl) instance, this);
 
-        if(mindmapsGraph.isBatchLoadingEnabled()){
+        if(getMindmapsGraph().isBatchLoadingEnabled()){
             setHash(null);
         } else {
             setHash(roleMap);

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationTypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RelationTypeImpl.java
@@ -68,7 +68,7 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
     public RelationType deleteHasRole(RoleType roleType) {
         deleteEdgeTo(Schema.EdgeLabel.HAS_ROLE, roleType);
         //Add castings of roleType to make sure relations are still valid
-        ((RoleTypeImpl) roleType).castings().forEach(casting -> mindmapsGraph.getConceptLog().putConcept(casting));
+        ((RoleTypeImpl) roleType).castings().forEach(casting -> getMindmapsGraph().getConceptLog().putConcept(casting));
         return this;
     }
 }

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceImpl.java
@@ -127,10 +127,9 @@ class ResourceImpl<D> extends InstanceImpl<Resource<D>, ResourceType<D>> impleme
      *
      * @return The value casted to the correct type
      */
-    @SuppressWarnings("unchecked")
     @Override
     public D getValue(){
-        return (D) getProperty(dataType().getConceptProperty());
+        return getProperty(dataType().getConceptProperty());
     }
 
     @Override

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceTypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceTypeImpl.java
@@ -39,9 +39,10 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
         super(v, type, mindmapsGraph);
     }
 
-    ResourceTypeImpl(Vertex v, Type type, AbstractMindmapsGraph mindmapsGraph, DataType<D> dataType) {
+    ResourceTypeImpl(Vertex v, Type type, AbstractMindmapsGraph mindmapsGraph, DataType<D> dataType, boolean isUnique) {
         super(v, type, mindmapsGraph);
         setImmutableProperty(Schema.ConceptProperty.DATA_TYPE, dataType.getName());
+        setImmutableProperty(Schema.ConceptProperty.IS_UNIQUE, isUnique);
     }
 
     /**
@@ -89,5 +90,11 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
         if(object == null)
             return null;
         return (String) object;
+    }
+
+    @Override
+    public Boolean isUnique() {
+        Object object = getProperty(Schema.ConceptProperty.IS_UNIQUE);
+        return (object == null) ? null : (Boolean) object;
     }
 }

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceTypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/ResourceTypeImpl.java
@@ -74,11 +74,10 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
      * @return The data type which instances of this resource must conform to.
      */
     //This unsafe cast is suppressed because at this stage we do not know what the type is when reading from the rootGraph.
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "SuspiciousMethodCalls"})
     @Override
     public DataType<D> getDataType() {
-        Object object = getProperty(Schema.ConceptProperty.DATA_TYPE);
-        return (DataType<D>) DataType.SUPPORTED_TYPES.get(String.valueOf(object));
+        return (DataType<D>) DataType.SUPPORTED_TYPES.get(getProperty(Schema.ConceptProperty.DATA_TYPE));
     }
 
     /**
@@ -86,15 +85,15 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
      */
     @Override
     public String getRegex() {
-        Object object = getProperty(Schema.ConceptProperty.REGEX);
-        if(object == null)
-            return null;
-        return (String) object;
+        return getProperty(Schema.ConceptProperty.REGEX);
     }
 
+    /**
+     *
+     * @return True if the resource type is unique and its instances are limited to one connection to an entity
+     */
     @Override
     public Boolean isUnique() {
-        Object object = getProperty(Schema.ConceptProperty.IS_UNIQUE);
-        return (object == null) ? null : (Boolean) object;
+        return getProperty(Schema.ConceptProperty.IS_UNIQUE);
     }
 }

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RoleTypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RoleTypeImpl.java
@@ -82,7 +82,7 @@ class RoleTypeImpl extends TypeImpl<RoleType, Instance> implements RoleType{
      */
     public Set<CastingImpl> castings(){
         Set<CastingImpl> castings = new HashSet<>();
-        getIncomingNeighbours(Schema.EdgeLabel.ISA).forEach(concept -> ((CastingImpl) concept).getRelations().forEach(relation -> mindmapsGraph.getConceptLog().putConcept(relation)));
+        getIncomingNeighbours(Schema.EdgeLabel.ISA).forEach(concept -> ((CastingImpl) concept).getRelations().forEach(relation -> getMindmapsGraph().getConceptLog().putConcept(relation)));
         return castings;
     }
 }

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RuleImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/RuleImpl.java
@@ -67,10 +67,7 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      */
     @Override
     public String getLHS() {
-        Object object = getProperty(Schema.ConceptProperty.RULE_LHS);
-        if(object == null)
-            return null;
-        return (String) object;
+        return getProperty(Schema.ConceptProperty.RULE_LHS);
     }
 
     /**
@@ -79,10 +76,7 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      */
     @Override
     public String getRHS() {
-        Object object = getProperty(Schema.ConceptProperty.RULE_RHS);
-        if(object == null)
-            return null;
-        return (String) object;
+        return getProperty(Schema.ConceptProperty.RULE_RHS);
     }
 
 
@@ -92,9 +86,8 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      * @return
      */
     @Override
-    public boolean getExpectation() {
-        Object object = getProperty(Schema.ConceptProperty.IS_EXPECTED);
-        return object != null && Boolean.parseBoolean(object.toString());
+    public Boolean getExpectation() {
+        return getPropertyBoolean(Schema.ConceptProperty.IS_EXPECTED);
     }
 
     //TODO: Fill out details on this method
@@ -103,9 +96,8 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      * @return
      */
     @Override
-    public boolean isMaterialise() {
-        Object object = getProperty(Schema.ConceptProperty.IS_MATERIALISED);
-        return object != null && Boolean.parseBoolean(object.toString());
+    public Boolean isMaterialise() {
+        return getPropertyBoolean(Schema.ConceptProperty.IS_MATERIALISED);
     }
 
     /**

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/TypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/TypeImpl.java
@@ -224,7 +224,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
             currentSuperType.instances().forEach(concept -> {
                 if(concept.isInstance()){
                     ((InstanceImpl<?, ?>) concept).castings().forEach(
-                            instance -> mindmapsGraph.getConceptLog().putConcept(instance));
+                            instance -> getMindmapsGraph().getConceptLog().putConcept(instance));
                 }
             });
         }
@@ -259,7 +259,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
         //Add castings to tracking to make sure they can still be played.
         instances().forEach(concept -> {
             if (concept.isInstance()) {
-                ((InstanceImpl<?, ?>) concept).castings().forEach(casting -> mindmapsGraph.getConceptLog().putConcept(casting));
+                ((InstanceImpl<?, ?>) concept).castings().forEach(casting -> getMindmapsGraph().getConceptLog().putConcept(casting));
             }
         });
 
@@ -283,7 +283,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
         checkMetaType();
         setProperty(Schema.ConceptProperty.IS_ABSTRACT, isAbstract);
         if(isAbstract)
-            mindmapsGraph.getConceptLog().putConcept(this);
+            getMindmapsGraph().getConceptLog().putConcept(this);
         return getThis();
     }
 

--- a/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/TypeImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/graph/internal/TypeImpl.java
@@ -183,8 +183,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
      */
     @Override
     public Boolean isAbstract() {
-        Object object = getProperty(Schema.ConceptProperty.IS_ABSTRACT);
-        return object != null && Boolean.parseBoolean(object.toString());
+        return getPropertyBoolean(Schema.ConceptProperty.IS_ABSTRACT);
     }
 
     /**

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
@@ -171,7 +171,7 @@ public class ResourceTest {
         //Create Resources
         ResourceType primaryKeyType = mindmapsGraph.putResourceTypeUnique("My Primary Key", ResourceType.DataType.STRING).playsRole(primaryKeyRole);
         Resource pimaryKey1 = mindmapsGraph.putResource("A Primary Key 1", primaryKeyType);
-        Resource pimaryKey2 = mindmapsGraph.putResource("A Primary Key 1", primaryKeyType);
+        Resource pimaryKey2 = mindmapsGraph.putResource("A Primary Key 2", primaryKeyType);
 
         //Create Entities
         EntityType entityType = mindmapsGraph.putEntityType("My Entity Type").playsRole(entityRole);

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
@@ -19,12 +19,14 @@
 package io.mindmaps.graph.internal;
 
 import io.mindmaps.Mindmaps;
+import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
 import io.mindmaps.concept.RelationType;
 import io.mindmaps.concept.Resource;
 import io.mindmaps.concept.ResourceType;
 import io.mindmaps.concept.RoleType;
+import io.mindmaps.exception.ConceptNotUniqueException;
 import io.mindmaps.util.ErrorMessage;
 import org.junit.Before;
 import org.junit.Test;
@@ -156,5 +158,36 @@ public class ResourceTest {
                 containsString(ErrorMessage.INVALID_DATATYPE.getMessage("1", String.class.getName()))
         ));
         mindmapsGraph.putResource(1L, stringResourceType);
+    }
+
+    @Test
+    public void testUniqueResource(){
+        //Create Ontology
+        RoleType primaryKeyRole = mindmapsGraph.putRoleType("Primary Key Role");
+        RoleType entityRole = mindmapsGraph.putRoleType("Entity Role");
+        RelationType hasPrimaryKey = mindmapsGraph.putRelationType("Has Parimary Key").hasRole(primaryKeyRole).hasRole(entityRole);
+
+
+        //Create Resources
+        ResourceType primaryKeyType = mindmapsGraph.putResourceTypeUnique("My Primary Key", ResourceType.DataType.STRING).playsRole(primaryKeyRole);
+        Resource pimaryKey1 = mindmapsGraph.putResource("A Primary Key 1", primaryKeyType);
+        Resource pimaryKey2 = mindmapsGraph.putResource("A Primary Key 1", primaryKeyType);
+
+        //Create Entities
+        EntityType entityType = mindmapsGraph.putEntityType("My Entity Type").playsRole(entityRole);
+        Entity entity1 = mindmapsGraph.addEntity(entityType);
+        Entity entity2 = mindmapsGraph.addEntity(entityType);
+        Entity entity3 = mindmapsGraph.addEntity(entityType);
+
+        //Link Entities to resources
+        mindmapsGraph.addRelation(hasPrimaryKey).putRolePlayer(primaryKeyRole, pimaryKey1).putRolePlayer(entityRole, entity1);
+        mindmapsGraph.addRelation(hasPrimaryKey).putRolePlayer(primaryKeyRole, pimaryKey2).putRolePlayer(entityRole, entity2);
+
+        expectedException.expect(ConceptNotUniqueException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.RESOURCE_TYPE_UNIQUE.getMessage(pimaryKey1.getId(), entity1.getId()))
+        ));
+
+        mindmapsGraph.addRelation(hasPrimaryKey).putRolePlayer(primaryKeyRole, pimaryKey1).putRolePlayer(entityRole, entity3);
     }
 }

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTypeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTypeTest.java
@@ -37,6 +37,8 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ResourceTypeTest {
 
@@ -101,6 +103,15 @@ public class ResourceTypeTest {
                 containsString(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[abc]", thing.toString()))
         ));
         resourceType.setRegex("[abc]");
+    }
+
+    @Test
+    public void testGetUniqueResourceType(){
+        ResourceType unique = mindmapsGraph.putResourceTypeUnique("Random ID", ResourceType.DataType.LONG);
+        ResourceType notUnique = mindmapsGraph.putResourceType("Random ID 2", ResourceType.DataType.LONG);
+
+        assertTrue(unique.isUnique());
+        assertFalse(notUnique.isUnique());
     }
 
     @Test


### PR DESCRIPTION
- Allow creating unique resource types whose instances can only have ONE relation. 
- Enforce this rule when creating relations.
- Various clean ups of old Core API code.